### PR TITLE
wires --> inputs/outputs

### DIFF
--- a/bigraph_schema/type_system.py
+++ b/bigraph_schema/type_system.py
@@ -551,9 +551,6 @@ class TypeSystem:
         if path is None:
             path = []
 
-        # more_wires = state.get('wires', {})
-        # wires = deep_merge(wires, more_wires)
-
         for port_key, port_schema in schema.items():
             if port_key in wires:
                 subwires = wires[port_key]


### PR DESCRIPTION
Previously, edges had a single set of ports called "wires", which lead to differences in process-bigraph between a Process and a Step, the latter of which required "inputs" and "outputs". In order to reduce confusion and unify our model of an edge and edge subtypes, we have decided that all edges/processes/steps will have a consistent interface consisting of both a set of `inputs` ports and a set of `outputs` ports. 

Thinking through this, the previous behavior is equivalent to having the inputs and outputs be identical. In addition, these can now be asymmetrical which allows us to be more expressive in defining the interface of any edge/process in the system. 

The tests have been updated to reflect this change and are currently all passing as before. If this all looks good I can apply these changes downstream to process-bigraph. 