### PR TITLE
fixing fill_ports to get the expected results in bigraph-viz

### DIFF
--- a/bigraph_schema/type_system.py
+++ b/bigraph_schema/type_system.py
@@ -661,13 +661,13 @@ class TypeSystem:
 
                     peer = get_path(
                         top,
-                        path[:-1])
+                        path)
 
                     destination = establish_path(
                         peer,
                         subwires[:-1],
                         top=top,
-                        cursor=path[:-1])
+                        cursor=path)
 
                     destination_key = subwires[-1]
 


### PR DESCRIPTION
Running `core.complete()` on this was filling the projected chromosome and cytoplasm in the wrong location:

```
{ 'cell1': {
             'nucleus': { 'transcription': { '_type': 'process',
                                             'address': '',
                                             'config': {},
                                             'inputs': {'DNA': ['chromosome']},
                                             'interval': 0.0,
                                             'outputs': { 'RNA': [ '..',
                                                                   'cytoplasm']}}}},
}
```

This was the result:
```
{ 'cell1': { 'chromosome': {},
             'nucleus': { 'transcription': { '_type': 'process',
                                             'address': '',
                                             'config': {},
                                             'inputs': {'DNA': ['chromosome']},
                                             'interval': 0.0,
                                             'outputs': { 'RNA': [ '..',
                                                                   'cytoplasm']}}}},
  'cytoplasm': {}}
```

by adjusting these two lines in `fill_ports`, we now get the correct results:
```
{ 'cell1': {
             'cytoplasm': {},
             'nucleus': {  'chromosome': {},
                                  'transcription': { '_type': 'process',
                                             'address': '',
                                             'config': {},
                                             'inputs': {'DNA': ['chromosome']},
                                             'interval': 0.0,
                                             'outputs': { 'RNA': [ '..',
                                                                   'cytoplasm']}}}},
}
```