### PR TITLE
bind array

### DIFF
--- a/bigraph_schema/edge.py
+++ b/bigraph_schema/edge.py
@@ -30,9 +30,10 @@ class Edge:
         pass
 
 
-    def initial_state(self, config=None):  # TODO -- config could have a schema
+    def initial_state(self):
         """The initial state of the edge, which is passed to the core."""
-        return self.generate_state(config)
+        return {}
+
 
     @staticmethod
     def generate_state(config=None):  # TODO -- config could have a schema
@@ -41,6 +42,7 @@ class Edge:
         This could be used to create user-configured initial states based on the Edge's requirements.
         """
         return {}
+
 
     def inputs(self):
         return {}

--- a/bigraph_schema/edge.py
+++ b/bigraph_schema/edge.py
@@ -30,9 +30,17 @@ class Edge:
         pass
 
 
-    def initial_state(self):
-        return {}
+    def initial_state(self, config=None):  # TODO -- config could have a schema
+        """The initial state of the edge, which is passed to the core."""
+        return self.generate_state(config)
 
+    @staticmethod
+    def generate_state(config=None):  # TODO -- config could have a schema
+        """
+        Generate an initial state statically, without any instance-specific config.
+        This could be used to create user-configured initial states based on the Edge's requirements.
+        """
+        return {}
 
     def inputs(self):
         return {}

--- a/bigraph_schema/type_functions.py
+++ b/bigraph_schema/type_functions.py
@@ -1626,6 +1626,15 @@ def bind_enum(schema, state, key, subschema, substate, core):
 
     return new_schema, tuple(open)
 
+def bind_array(schema, state, key, subschema, substate, core):
+    if state is None:
+        state = core.default(schema)
+    if isinstance(key, str):
+        key = int(key)
+    state[key] = substate
+
+    return schema, state
+
 
 # ==========================
 # Resolve Functions Overview
@@ -2604,6 +2613,7 @@ base_types = {
         '_deserialize': deserialize_array,
         '_dataclass': dataclass_array,
         '_resolve': resolve_array,
+        '_bind': bind_array,
         '_type_parameters': [
             'shape',
             'data'],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '0.0.54'
+VERSION = '0.0.55'
 
 
 with open("README.md", "r") as readme:


### PR DESCRIPTION
In addition to the `bind_array` type function, this PR also introduces a static `generate_state` method to `Edge`, so that different edges can provide functionality to generate states compatible with their schema.