### PR TITLE
first attempt to fix a parsimonius warning based on an out of date example

### DIFF
--- a/bigraph_schema/parse.py
+++ b/bigraph_schema/parse.py
@@ -37,7 +37,7 @@ parameter_grammar = Grammar(
     nest = symbol colon tree
     type_name = symbol parameter_list?
     parameter_list = square_left expression (comma expression)* square_right
-    symbol = ~r"[\w\d-_/*&^%$#@!`+ ]+"
+    symbol = ~r"[\\w\\d-_/*&^%$#@!`+ ]+"
     dot = "."
     colon = ":"
     bar = "|"
@@ -49,7 +49,7 @@ parameter_grammar = Grammar(
     tilde = "~"
     not_newline = ~r"[^\\n\\r]"*
     newline = ~"[\\n\\r]+"
-    ws = ~"\s*"
+    ws = ~r"\\s*"
     nothing = ""
     """)
 


### PR DESCRIPTION
I have verified that the bigraph-schema and process-bigraph tests still pass.

This change removes the 'invalid escape sequence' warnings that come up when running tests in both these repositories.

I'd welcome other verification steps I can take before merge.