### PR TITLE
Fix set_apply()

### DIFF
--- a/bigraph_schema/type_functions.py
+++ b/bigraph_schema/type_functions.py
@@ -178,6 +178,9 @@ def set_apply(schema, current, update, top_schema, top_state, path, core):
                 subschema,
                 current.get(key),
                 value,
+                top_schema, 
+                top_state, 
+                path,
                 core)
 
         return current


### PR DESCRIPTION
When set_apply() function was called on a leaf node from within itself, it was missing arguments and throwing an error.