### PR TITLE
Bug fixes

### DIFF
--- a/bigraph_schema/methods/default.py
+++ b/bigraph_schema/methods/default.py
@@ -50,6 +50,10 @@ def default(schema: Wrap):
         return default(schema._value)
 
 @dispatch
+def default(schema: Maybe):
+    return None
+
+@dispatch
 def default(schema: Union):
     if schema._default is not None:
         return schema._default

--- a/bigraph_schema/methods/merge.py
+++ b/bigraph_schema/methods/merge.py
@@ -59,6 +59,9 @@ def merge(schema: Maybe, current, update, path=()):
 def merge(schema: Wrap, current, update, path=()):
     return merge(schema._value, current, update, path=path)
 
+@dispatch
+def merge(schema: Overwrite, current, update, path=()):
+    return update
 
 @dispatch
 def merge(schema: Union, current, update, path=()):

--- a/bigraph_schema/methods/merge.py
+++ b/bigraph_schema/methods/merge.py
@@ -105,43 +105,6 @@ def merge(schema: Tuple, current, update, path=()):
 
 
 @dispatch
-def merge(schema: Boolean, current, update, path=()) -> bool:
-    result = None
-    if update and update is not None:
-        result = update
-    elif current and current is not None:
-        result = current
-    else:
-        result = default(schema)
-        result = True if result == 'true' else False
-    return result
-
-
-@dispatch
-def merge(schema: Integer, current, update, path=()) -> int:
-    result = None
-    if update and update is not None:
-        result = update
-    elif current and current is not None:
-        result = current
-    else:
-        result = default(schema)
-    return int(result)
-
-
-@dispatch
-def merge(schema: Float, current, update, path=()) -> float:
-    result = None
-    if update and update is not None:
-        result = update
-    elif current and current is not None:
-        result = current
-    else:
-        result = default(schema)
-    return float(result)
-
-
-@dispatch
 def merge(schema: List, current, update, path=()):
     if path:
         head = path[0]
@@ -279,16 +242,14 @@ def merge(schema: Frame, current, update, path=()):
 @dispatch
 def merge(schema: Atom, current, update, path=()):
     result = None
-    if update and update is not None:
+    if update: # Checking if default
         result = update
-    elif current and current is not None:
+    elif current:
         result = current
-    # if update and update is not None:
-    #     result = update
-    # elif current and current is not None:
-    #     result = current
-    else:
-        result = default(schema)
+    elif update is not None:
+        result = update
+    elif current is not None:
+        result = current
 
     return result
 

--- a/bigraph_schema/methods/merge.py
+++ b/bigraph_schema/methods/merge.py
@@ -157,7 +157,7 @@ def merge(schema: Map, current, update, path=()):
         for key in current.keys() | update.keys():
             if key in update:
                 if key in current:
-                    if not key.startswith('_'):
+                    if not isinstance(key, str) or not key.startswith('_'):
                         result[key] = merge(
                             schema._value,
                             current[key],

--- a/bigraph_schema/methods/merge.py
+++ b/bigraph_schema/methods/merge.py
@@ -105,6 +105,32 @@ def merge(schema: Tuple, current, update, path=()):
 
 
 @dispatch
+def merge(schema: Boolean, current, update, path=()) -> bool:
+    result = update if update is not None else current
+    if result is None:
+        result = default(schema)
+    if result == 'true':
+        return True
+    return False
+
+
+@dispatch
+def merge(schema: Integer, current, update, path=()) -> int:
+    result = update if update is not None else current
+    if result is None:
+        result = default(schema)
+    return int(result)
+
+
+@dispatch
+def merge(schema: Float, current, update, path=()) -> float:
+    result = update if update is not None else current
+    if result is None:
+        result = default(schema)
+    return float(result)
+
+
+@dispatch
 def merge(schema: List, current, update, path=()):
     if path:
         head = path[0]

--- a/bigraph_schema/methods/merge.py
+++ b/bigraph_schema/methods/merge.py
@@ -106,26 +106,37 @@ def merge(schema: Tuple, current, update, path=()):
 
 @dispatch
 def merge(schema: Boolean, current, update, path=()) -> bool:
-    result = update if update is not None else current
-    if result is None:
+    result = None
+    if update and update is not None:
+        result = update
+    elif current and current is not None:
+        result = current
+    else:
         result = default(schema)
-    if result == 'true':
-        return True
-    return False
+        result = True if result == 'true' else False
+    return result
 
 
 @dispatch
 def merge(schema: Integer, current, update, path=()) -> int:
-    result = update if update is not None else current
-    if result is None:
+    result = None
+    if update and update is not None:
+        result = update
+    elif current and current is not None:
+        result = current
+    else:
         result = default(schema)
     return int(result)
 
 
 @dispatch
 def merge(schema: Float, current, update, path=()) -> float:
-    result = update if update is not None else current
-    if result is None:
+    result = None
+    if update and update is not None:
+        result = update
+    elif current and current is not None:
+        result = current
+    else:
         result = default(schema)
     return float(result)
 

--- a/bigraph_schema/methods/realize.py
+++ b/bigraph_schema/methods/realize.py
@@ -195,7 +195,7 @@ def realize(core, schema: Map, encode, path=()):
         value_schemas = []
 
         for key, value in encode.items():
-            if key.startswith('_'):
+            if isinstance(key, str) and key.startswith('_'):
                 continue
             else:
                 subschema, substate, submerges = realize(core, schema._value, value, path+(key,))

--- a/tests.py
+++ b/tests.py
@@ -534,7 +534,13 @@ def test_resolve_conflict(core):
             'inputs': {'place': ['number']},
             'outputs': {'number': ['other place']}}}
 
-    schema, realized = core.realize({}, state)
+    conflict = False
+    try:
+        schema, realized = core.realize({}, state)
+    except Exception as e:
+        conflict = True
+
+    assert conflict
 
 
 def test_unify(core):
@@ -797,4 +803,4 @@ if __name__ == '__main__':
     test_access_tuple(core)
     test_serialize_realize_shape(core)
 
-    # test_resolve_conflict(core)
+    test_resolve_conflict(core)


### PR DESCRIPTION
When working the ReaDDy process, there where problems with:

- How the map type interpreted keys.
- How it merges overwrite wrappers into state.
- The default value for the maybe wrapper. 
- Merge functions for atomic types have their string representation of the schema actualized.