### PR TITLE
Optimize runtime communication performance 

### DIFF
--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -258,6 +258,7 @@ class Core:
         self.registry = {}
         self.link_registry = {}
         self.method_registry = {}
+        self._access_cache = {}
 
         self.parse_visitor = CoreVisitor(self)
 
@@ -271,6 +272,8 @@ class Core:
             self.update_type(key, found)
         else:
             self.registry[key] = found
+        # Invalidate access cache since type registry changed
+        self._access_cache.pop(key, None)
 
     def register_types(self, types):
         """Bulk register multiple type keys into the operation registry."""
@@ -371,10 +374,6 @@ class Core:
         normalized in-memory representations.
         """
 
-        # TODO: consider other terms for this?
-        #   * compile
-        #   * parse
-
         if is_dataclass(key):
             return key
 
@@ -383,7 +382,6 @@ class Core:
                 try:
                     return visit_expression(key, self.parse_visitor)
                 except Exception as e:
-                    import ipdb; ipdb.set_trace()
                     raise Exception(f'unable to parse type "{key}"\n\ndue to\n{e}')
             else:
                 entry = self.registry[key]
@@ -707,6 +705,107 @@ class Core:
                 f'inverting state\n  {view}\naccording to ports schema\n  {ports_schema}\nbut wires are not recognized\n  {wires}')
 
         return project_schema, project_state
+
+    def precompile_project(self, ports_schema, wires, path):
+        """Precompile the schema resolution for project_ports.
+
+        Returns a compiled structure that can be used by project_ports_fast
+        to skip repeated schema resolution. Call once per process, then use
+        project_ports_fast on each timestep.
+
+        Returns:
+            A compiled projection structure, or None if the wires pattern
+            is not supported for fast projection.
+        """
+        if isinstance(wires, str):
+            wires = [wires]
+
+        if isinstance(wires, (list, tuple)):
+            destination = resolve_path(list(path) + list(wires))
+            project_schema = self.resolve({}, ports_schema, path=destination)
+            return ('leaf', destination, project_schema)
+
+        elif isinstance(wires, dict):
+            sub_compiled = []
+            for key, subwires in wires.items():
+                subports, _ = self.jump(ports_schema, {}, key)
+                if subports is None:
+                    continue
+                sub = self.precompile_project(subports, subwires, path)
+                if sub is None:
+                    return None
+                sub_compiled.append((key, sub))
+
+            # Precompute the merged schema
+            project_schema = Node()
+            for _, sub in sub_compiled:
+                if sub[0] == 'leaf':
+                    project_schema = resolve(project_schema, sub[2])
+                elif sub[0] == 'dict':
+                    project_schema = resolve(project_schema, sub[2])
+            return ('dict', sub_compiled, project_schema)
+
+        return None
+
+    @staticmethod
+    def _set_nested(target, path, value):
+        """Set a value at a nested path in a dict, creating intermediates."""
+        current = target
+        for key in path[:-1]:
+            if key not in current:
+                current[key] = {}
+            current = current[key]
+        if path:
+            current[path[-1]] = value
+
+    @staticmethod
+    def _merge_nested(target, source):
+        """Recursively merge source dict into target dict."""
+        for key, value in source.items():
+            if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+                Core._merge_nested(target[key], value)
+            else:
+                target[key] = value
+
+    def project_ports_fast(self, compiled, view):
+        """Fast version of project_ports using precompiled schema.
+
+        Args:
+            compiled: Result from precompile_project.
+            view: The process update values.
+
+        Returns:
+            (project_schema, project_state) tuple.
+        """
+        kind = compiled[0]
+
+        if kind == 'leaf':
+            _, destination, project_schema = compiled
+            # Build nested dict directly instead of calling self.merge
+            project_state = {}
+            self._set_nested(project_state, destination, view)
+            return project_schema, project_state
+
+        elif kind == 'dict':
+            _, sub_compiled, full_schema = compiled
+            if isinstance(view, list):
+                result = [
+                    self.project_ports_fast(('dict', sub_compiled, full_schema), state)
+                    for state in view]
+                project_schema = Tuple(_values=[item[0] for item in result])
+                project_state = [item[1] for item in result]
+                return project_schema, project_state
+            else:
+                project_state = {}
+                project_schema = full_schema
+                for key, sub in sub_compiled:
+                    if key not in view:
+                        continue
+                    subview = view[key]
+                    _, substate = self.project_ports_fast(sub, subview)
+                    if substate is not None:
+                        self._merge_nested(project_state, substate)
+                return project_schema, project_state
 
     def project(self, schema, state, link_path, view, ports_key='outputs'):
         found = self.access(schema)

--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -259,6 +259,7 @@ class Core:
         self.link_registry = {}
         self.method_registry = {}
         self._access_cache = {}
+        self._link_cache = {}
 
         self.parse_visitor = CoreVisitor(self)
 
@@ -809,7 +810,9 @@ class Core:
         """Precompile both view and project operations for a link.
 
         Convenience method that combines precompile_view and
-        precompile_project for a process at the given path.
+        precompile_project for a process at the given path. The result
+        is cached internally keyed by link_path. Call invalidate_link()
+        or re-call this method to refresh after wiring changes.
 
         Args:
             schema: The full schema tree.
@@ -838,9 +841,26 @@ class Core:
             else:
                 compiled['project'] = None
 
+            self._link_cache[tuple(link_path)] = compiled
             return compiled
         except Exception:
             return None
+
+    def get_compiled_link(self, link_path):
+        """Retrieve the cached compiled link structure for a path.
+
+        Returns:
+            The cached compiled dict, or None if not cached.
+        """
+        return self._link_cache.get(tuple(link_path))
+
+    def invalidate_link(self, link_path):
+        """Remove the cached compiled structure for a link path.
+
+        Call this when wiring changes for a link so that the next
+        precompile_link call rebuilds the compiled structure.
+        """
+        self._link_cache.pop(tuple(link_path), None)
 
     def precompile_project(self, ports_schema, wires, path):
         """Precompile the schema resolution for project_ports.

--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -706,6 +706,142 @@ class Core:
 
         return project_schema, project_state
 
+    def _resolve_wire_paths(self, wires, parent_path):
+        """Recursively resolve wires to absolute state paths.
+
+        Returns a structure matching the wires layout, but with leaf wire
+        lists resolved to absolute tuple paths. Returns None if the wires
+        contain unsupported patterns.
+        """
+        if isinstance(wires, str):
+            wires = [wires]
+
+        if isinstance(wires, (list, tuple)):
+            return resolve_path(list(parent_path) + list(wires))
+
+        elif isinstance(wires, dict):
+            resolved = {}
+            for port_key, subwires in wires.items():
+                sub_resolved = self._resolve_wire_paths(subwires, parent_path)
+                if sub_resolved is None:
+                    return None
+                resolved[port_key] = sub_resolved
+            return resolved
+
+        return None
+
+    def precompile_view(self, schema, state, link_path):
+        """Precompile a view operation for a link at the given path.
+
+        Resolves the link's input port schemas and wires once, then
+        pre-resolves wire paths to absolute state paths so that
+        view_fast() can extract values via direct get_path() lookups
+        instead of traversing the schema tree.
+
+        Args:
+            schema: The full schema tree.
+            state: The full state tree.
+            link_path: Path to the link (process/step) in the tree.
+
+        Returns:
+            A compiled view structure for use with view_fast(), or None
+            if precompilation is not possible for this link.
+        """
+        try:
+            link_schema, link_state = self.traverse(schema, state, link_path)
+            parent_path = link_path[:-1]
+            ports_schema = getattr(link_schema, '_inputs', None)
+            wires = link_state.get('inputs') or {}
+
+            if ports_schema is None:
+                return None
+
+            resolved = self._resolve_wire_paths(wires, parent_path)
+            if resolved is not None:
+                return ('resolved', resolved)
+
+            # Fall back to storing port schema and wires for view_ports
+            return ('ports', ports_schema, wires, parent_path)
+        except Exception:
+            return None
+
+    def view_fast(self, compiled, state):
+        """Extract input state using a precompiled view.
+
+        Args:
+            compiled: Result from precompile_view().
+            state: The current full state tree.
+
+        Returns:
+            The input state dict for the process.
+        """
+        kind = compiled[0]
+        if kind == 'resolved':
+            return self._view_resolved(compiled[1], state)
+        elif kind == 'ports':
+            _, ports_schema, wires, parent_path = compiled
+            return self.view_ports(
+                None, state, parent_path, ports_schema, wires)
+
+    @staticmethod
+    def _get_path(tree, path):
+        """Follow a path of keys down a nested dict."""
+        for key in path:
+            if not isinstance(tree, dict) or key not in tree:
+                return None
+            tree = tree[key]
+        return tree
+
+    @staticmethod
+    def _view_resolved(resolved_paths, state):
+        """Extract state values using pre-resolved absolute paths."""
+        if isinstance(resolved_paths, tuple):
+            return Core._get_path(state, resolved_paths)
+        elif isinstance(resolved_paths, dict):
+            result = {}
+            for port_key, sub_paths in resolved_paths.items():
+                value = Core._view_resolved(sub_paths, state)
+                if value is not None:
+                    result[port_key] = value
+            return result
+
+    def precompile_link(self, schema, state, link_path):
+        """Precompile both view and project operations for a link.
+
+        Convenience method that combines precompile_view and
+        precompile_project for a process at the given path.
+
+        Args:
+            schema: The full schema tree.
+            state: The full state tree.
+            link_path: Path to the link (process/step) in the tree.
+
+        Returns:
+            A dict with 'view' and 'project' compiled structures,
+            or None if precompilation fails.
+        """
+        try:
+            link_schema, link_state = self.traverse(schema, state, link_path)
+            parent_path = link_path[:-1]
+
+            compiled = {}
+
+            # Compile view (inputs)
+            compiled['view'] = self.precompile_view(schema, state, link_path)
+
+            # Compile project (outputs)
+            out_ports_schema = getattr(link_schema, '_outputs', None)
+            out_wires = link_state.get('outputs') or {}
+            if out_ports_schema is not None:
+                compiled['project'] = self.precompile_project(
+                    out_ports_schema, out_wires, parent_path)
+            else:
+                compiled['project'] = None
+
+            return compiled
+        except Exception:
+            return None
+
     def precompile_project(self, ports_schema, wires, path):
         """Precompile the schema resolution for project_ports.
 

--- a/bigraph_schema/methods/realize.py
+++ b/bigraph_schema/methods/realize.py
@@ -344,10 +344,9 @@ def realize_link(core, schema: Link, encode, path=()):
             'data': data}
 
     if 'instance' in encode:
-        edge_instance = encode['instance']
-        config = encode['config']
-
-        # return schema, encode, []
+        # Instance already exists — skip full realization.
+        # Return current state as-is with no new merges.
+        return schema, encode, []
 
     else:
         protocol = address.get('protocol', 'local')

--- a/bigraph_schema/methods/realize.py
+++ b/bigraph_schema/methods/realize.py
@@ -330,6 +330,10 @@ def default_wires(schema):
 
 
 def realize_link(core, schema: Link, encode, path=()):
+    # Invalidate any cached compiled link structure so it will be
+    # rebuilt with the new wiring after realization.
+    core.invalidate_link(path)
+
     address = encode.get('address', 'local:edge')
 
     if isinstance(address, str):


### PR DESCRIPTION
Adds precompiled view and project operations to Core, eliminating repeated schema                                              
  traversal during simulation timesteps. Any consumer of bigraph-schema benefits —
  not just process-bigraph's Composite.                                                                                          
                                                                                                                                 
  ### New Core methods                                                                                                           
                                                                                                                                 
  - `precompile_view(schema, state, link_path)` — pre-resolves input wire paths to                                               
    absolute state paths                                    
  - `view_fast(compiled, state)` — extracts input state via direct dict lookups                                                  
    (bypasses `access`/`traverse`/`view_ports`)                                                                                  
  - `precompile_project(ports_schema, wires, path)` — precomputes output schema                                                  
    resolution once                                                                                                              
  - `project_ports_fast(compiled, view)` — projects updates via direct dict                                                      
    construction (bypasses plum-dispatched `merge`/`jump`/`resolve`)                                                             
  - `precompile_link(schema, state, link_path)` — convenience method that                                                        
    precompiles both view and project for a link                                                                                 
  - `_resolve_wire_paths(wires, parent_path)` — resolves wire lists/dicts to                                                     
    absolute tuple paths                                                                                                         
                                                                                                                                 
  ### Other changes                                                                                                              
   
  - Early return in `realize_link()` when process instance already exists, skipping                                              
    redundant interface resolution, port schema merging, and wire realization
  - Remove stray `ipdb.set_trace()` in `access()`                                                                                
                                                                                                                                 
  ## Benchmark results                                                                                                           
                                                                                                                                 
  Measured with process-bigraph benchmark suite (20 processes, 5 ports each, 20 timesteps):                                      
   
  | Operation | Before | After | Speedup |                                                                                       
  |---|---|---|---|                                         
  | `view` (input extraction) | 0.234s | 0.003s | **78x** |                                                                      
  | `project_ports` | 0.080s | 0.002s | **40x** |                                                                                
  | `realize` (per-run) | 0.379s | 0.011s | **34x** |                                                                            
  | Total `run()` loop | 0.486s | 0.048s | **10x** |                                                                             
                                                                                                                                 
  End-to-end per-timestep results across scenarios:                                                                              
                                                                                                                                 
  | Scenario | Before (ms/step) | After (ms/step) | Speedup |                                                                    
  |---|---|---|---|
  | 100 processes, 1 port | 22.2 | 2.1 | **10.4x** |                                                                             
  | 10 procs, 50 ports | 73.3 | 1.7 | **44x** |                                                                                  
  | 10 procs, 20 ports | 14.6 | 0.8 | **19x** |                                                                                  
  | 10 procs, 5 ports, 100 steps | 2.0 | 0.26 | **7.7x** |                                                                       
                                                                                                                                 
  ## Companion PR                                           
                                                                                                                                 
  - vivarium-collective/process-bigraph — uses `precompile_link`/`view_fast`/`project_ports_fast`                                
    in Composite and adds the benchmark suite
