### PR TITLE
Add units demo notebook

### DIFF
--- a/.github/workflows/notebook_to_html.yml
+++ b/.github/workflows/notebook_to_html.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'notebooks/demo.ipynb'
       - 'notebooks/core.ipynb'
+      - 'notebooks/units.ipynb'
 
 jobs:
   convert:
@@ -30,6 +31,7 @@ jobs:
       run: |
         jupyter nbconvert --to html notebooks/demo.ipynb
         jupyter nbconvert --to html notebooks/core.ipynb
+        jupyter nbconvert --to html notebooks/units.ipynb
 
     - name: Commit and push HTML to gh-pages branch
       run: |
@@ -38,11 +40,14 @@ jobs:
         git fetch origin
         mv notebooks/demo.html /tmp/demo.html
         mv notebooks/core.html /tmp/core.html
+        mv notebooks/units.html /tmp/units.html
         git checkout gh-pages || git checkout -b gh-pages
         git pull origin gh-pages
         mv /tmp/demo.html notebooks/demo.html
-        mv /tmp/core.html notebooks/core.html 
+        mv /tmp/core.html notebooks/core.html
+        mv /tmp/units.html notebooks/units.html
         git add notebooks/demo.html
         git add notebooks/core.html
-        git diff-index --quiet HEAD || git commit -m "Update HTML files" 
+        git add notebooks/units.html
+        git diff-index --quiet HEAD || git commit -m "Update HTML files"
         git push origin gh-pages || true

--- a/.github/workflows/notebook_to_html.yml
+++ b/.github/workflows/notebook_to_html.yml
@@ -2,6 +2,8 @@ name: Convert Jupyter Notebook to HTML
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'notebooks/demo.ipynb'
       - 'notebooks/core.ipynb'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/bigraph-schema.svg)](https://pypi.org/project/bigraph-schema/)
 [![Tutorial](https://img.shields.io/badge/GitHub%20Pages-Tutorial-brightgreen)](https://vivarium-collective.github.io/bigraph-schema/notebooks/demo.html)
+[![Units Demo](https://img.shields.io/badge/GitHub%20Pages-Units%20demo-blue)](https://vivarium-collective.github.io/bigraph-schema/notebooks/units.html)
 
 `bigraph-schema` provides a serializable type schema for compositional and multiscale modeling.  
 It defines a compact, extensible language for describing hierarchical data structures — the foundation of the Vivarium 2.0 simulation framework.
@@ -27,6 +28,8 @@ The following resources provide guided introductions and examples:
 - [Type System Overview](https://vivarium-collective.github.io/bigraph-schema/notebooks/core.html) – Demonstrates how to use the `Core` API for schema inference, normalization, and serialization.
 
 - [Bigraph Schema Basics Tutorial](https://vivarium-collective.github.io/bigraph-viz/notebooks/basics.html) – Explains how to compose and visualize schema graphs using the `bigraph-schema` syntax.
+
+- [Units Demo](https://vivarium-collective.github.io/bigraph-schema/notebooks/units.html) – Demonstrates `Quantity`, `Number._units`, and wire-level unit conversion.
 
 
 ---

--- a/notebooks/_build_units_notebook.py
+++ b/notebooks/_build_units_notebook.py
@@ -1,0 +1,144 @@
+"""Build notebooks/units.ipynb from cell sources defined below.
+
+Run from repo root: ``PYTHONPATH=. uv run python3 notebooks/_build_units_notebook.py``
+Re-runs are idempotent: overwrites units.ipynb each time.
+"""
+import json
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Cells: list of (cell_type, source_lines) tuples.
+# Keep one logical thought per cell. Markdown cells are prose; code cells run.
+# ---------------------------------------------------------------------------
+
+CELLS = []
+
+def md(text: str) -> None:
+    CELLS.append(("markdown", text))
+
+def code(text: str) -> None:
+    CELLS.append(("code", text))
+
+# ---------- Title + intro ----------
+md("""\
+# Units in `bigraph-schema`
+
+`bigraph-schema` ships two complementary mechanisms for working with physical units:
+
+1. **`Quantity`** — the runtime value carries its units alongside its magnitude (backed by [`pint`](https://pint.readthedocs.io/)). You can call `.to(other_unit)`, do unit-safe arithmetic, and inspect `.dimensionality` at runtime.
+2. **`Number._units`** — a schema-level annotation. The runtime value is a plain `float`; the unit string lives only on the schema.
+
+A third feature ties them together: when a state's schema declares `_units` and connects to a port that declares a different `_units`, `bigraph-schema` computes a scalar conversion factor at compile time so the value seen through the port is in the port's units.
+
+This notebook walks through each of these.
+""")
+
+# ---------- Setup ----------
+md("## Setup")
+code("""\
+from bigraph_schema import allocate_core
+core = allocate_core()
+""")
+
+# ---------- Section 1: Quantity ----------
+md("""\
+## 1. `Quantity` — units carried at runtime
+
+Use `'quantity'` when you want unit-aware arithmetic and conversion on the value itself. `realize` accepts several encodings; `serialize` always produces `{units, magnitude}`.
+""")
+
+md("### Defining a quantity schema")
+code("""\
+quantity_schema = core.access({
+    '_type': 'quantity',
+    'units': {'mol': 1, 'L': -1},
+})
+quantity_schema
+""")
+
+code("""\
+core.render(quantity_schema)
+""")
+
+md("### Realize from a `{magnitude, units}` dict")
+code("""\
+_, q, _ = core.realize(
+    quantity_schema,
+    {'magnitude': 2.0, 'units': {'mol': 1, 'L': -1}},
+)
+q
+""")
+
+code("""\
+type(q).__name__, q.magnitude, str(q.units)
+""")
+
+md("### Realize from a bare numeric (uses the schema's units)")
+code("""\
+_, q_bare, _ = core.realize(quantity_schema, 5.0)
+q_bare
+""")
+
+md("### Realize from a parseable string")
+code("""\
+_, q_str, _ = core.realize(quantity_schema, '2.1 millimolar')
+q_str
+""")
+
+md("### Unit-aware operations at runtime")
+code("""\
+q.to('mmol/L')
+""")
+
+code("""\
+q.dimensionality
+""")
+
+code("""\
+(q * 3).to('mol/L')
+""")
+
+md("### Serialize roundtrip")
+code("""\
+encoded = core.serialize(quantity_schema, q)
+encoded
+""")
+
+code("""\
+_, q_back, _ = core.realize(quantity_schema, encoded)
+q_back == q
+""")
+
+# ---------- Section 2 placeholder — filled in Task 2 ----------
+# ---------- Section 3 placeholder — filled in Task 3 ----------
+
+def cell_dict(cell_type: str, source: str) -> dict:
+    src_lines = source.splitlines(keepends=True)
+    base = {
+        "cell_type": cell_type,
+        "id": uuid.uuid4().hex[:8],
+        "metadata": {},
+        "source": src_lines,
+    }
+    if cell_type == "code":
+        base.update({"execution_count": None, "outputs": []})
+    return base
+
+nb = {
+    "cells": [cell_dict(t, s) for t, s in CELLS],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        },
+        "language_info": {"name": "python"},
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+out = Path(__file__).resolve().parent / "units.ipynb"
+out.write_text(json.dumps(nb, indent=1))
+print(f"wrote {out}")

--- a/notebooks/_build_units_notebook.py
+++ b/notebooks/_build_units_notebook.py
@@ -110,7 +110,44 @@ _, q_back, _ = core.realize(quantity_schema, encoded)
 q_back == q
 """)
 
-# ---------- Section 2 placeholder — filled in Task 2 ----------
+# ---------- Section 2: Number._units ----------
+md("""\
+## 2. `Number._units` — units as metadata
+
+Use `_units` on a numeric type when you want to record the unit but keep the runtime value as a plain `float` (or numpy array). The unit string lives **only on the schema** — at runtime the value has no awareness of its units.
+""")
+
+md("### Defining a unit-annotated float schema")
+code("""\
+float_schema = core.access({'_type': 'float', '_units': 'mol/L'})
+float_schema
+""")
+
+code("""\
+core.render(float_schema)
+""")
+
+md("### The runtime value is a plain `float`")
+code("""\
+_, x, _ = core.realize(float_schema, 2.5)
+x, type(x).__name__
+""")
+
+md("### Serialize is just the number")
+code("""\
+core.serialize(float_schema, x)
+""")
+
+md("""\
+### When to use which
+
+| Approach        | Runtime value     | Unit info lives in | Use when                                            |
+|-----------------|-------------------|--------------------|-----------------------------------------------------|
+| `Number._units` | plain `float`     | schema annotation  | hot numerical paths; downstream code expects floats |
+| `Quantity`      | `pint.Quantity`   | the value itself   | unit-safe arithmetic / introspection at runtime     |
+
+`_units` is the right default for high-throughput numerics — no per-value pint overhead, and unit-aware wiring (Section 3) still works. Reach for `Quantity` when you need `.to()` or unit-checked arithmetic on individual values.
+""")
 # ---------- Section 3 placeholder — filled in Task 3 ----------
 
 def cell_dict(cell_type: str, source: str) -> dict:

--- a/notebooks/_build_units_notebook.py
+++ b/notebooks/_build_units_notebook.py
@@ -148,7 +148,71 @@ md("""\
 
 `_units` is the right default for high-throughput numerics — no per-value pint overhead, and unit-aware wiring (Section 3) still works. Reach for `Quantity` when you need `.to()` or unit-checked arithmetic on individual values.
 """)
-# ---------- Section 3 placeholder — filled in Task 3 ----------
+# ---------- Section 3: wire-level conversion ----------
+md("""\
+## 3. Unit conversion across wires
+
+When a state's schema declares `_units` and a port's schema declares a *different* `_units`, `bigraph-schema` doesn't silently mismatch — it computes a scalar conversion factor at compile time (using `pint`) and applies it during view/projection. The relevant logic is `Core._compute_unit_scale` in `bigraph_schema/core.py`.
+
+You can call it directly to see what happens for a given pair of units.
+""")
+
+md("### Compatible units: a real scale factor")
+code("""\
+core._compute_unit_scale('fg', 'g')
+""")
+
+code("""\
+core._compute_unit_scale('mmol/L', 'mol/L')
+""")
+
+md("""\
+### No-op cases
+
+`_compute_unit_scale` returns `1.0` (a true pass-through) in three cases:
+
+- one side has no unit declared (`''`)
+- the units match exactly
+- one side is `'dimensionless'`
+""")
+
+code("""\
+core._compute_unit_scale('', 'g'), core._compute_unit_scale('g', 'g'), core._compute_unit_scale('dimensionless', 'g')
+""")
+
+md("""\
+### Incompatible units raise
+
+Asking pint to convert `fg` to `mol` is meaningless; the call raises. (In wire resolution this is caught and falls back to `1.0`, but it's intended to surface as a wire validation error — see the docstring in `core.py`.)
+""")
+
+code("""\
+try:
+    core._compute_unit_scale('fg', 'mol')
+except Exception as exc:
+    print(type(exc).__name__, exc)
+""")
+
+md("""\
+### How this plays out in a schema
+
+Picture a composite where a state at path `x` is stored in `fg` and a process reads it through a port declared in `g`:
+
+```python
+schema = {
+    'x': {'_type': 'float', '_units': 'fg'},
+    'proc': {
+        '_type': 'process',
+        'inputs': {'mass': {'_type': 'float', '_units': 'g'}},
+        ...
+    },
+}
+```
+
+When the wire from `proc.inputs.mass` resolves down to `x`, `bigraph-schema` computes `1e-15` once and caches it. Each view of the port multiplies the underlying `float` by `1e-15` so the process always sees grams, while storage stays in femtograms.
+
+The full machinery — `_collect_view_scales`, `view`, `project`, `apply` — is internal to `Core` and is exercised end-to-end in [`process-bigraph`](https://github.com/vivarium-collective/process-bigraph). For this notebook we stop at showing the scale computation itself.
+""")
 
 def cell_dict(cell_type: str, source: str) -> dict:
     src_lines = source.splitlines(keepends=True)

--- a/notebooks/units.ipynb
+++ b/notebooks/units.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "54efcad2",
+   "id": "ca7527eb",
    "metadata": {},
    "source": [
     "# Units in `bigraph-schema`\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4daa2787",
+   "id": "286dc8dc",
    "metadata": {},
    "source": [
     "## Setup"
@@ -28,13 +28,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b99d3f75",
+   "id": "bb0e652b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:10.655089Z",
-     "iopub.status.busy": "2026-05-12T20:51:10.654814Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.053477Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.053089Z"
+     "iopub.execute_input": "2026-05-12T20:53:02.948481Z",
+     "iopub.status.busy": "2026-05-12T20:53:02.948383Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.360238Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.359800Z"
     }
    },
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "589e8c2f",
+   "id": "72d8eda9",
    "metadata": {},
    "source": [
     "## 1. `Quantity` — units carried at runtime\n",
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2660a511",
+   "id": "ee8ac376",
    "metadata": {},
    "source": [
     "### Defining a quantity schema"
@@ -64,13 +64,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e09d7f95",
+   "id": "2e4dc5fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.054903Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.054815Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.060233Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.059935Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.361590Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.361509Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.367455Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.367066Z"
     }
    },
    "outputs": [
@@ -96,13 +96,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b63b025d",
+   "id": "4d1333d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.061331Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.061287Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.065177Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.064904Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.368417Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.368367Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.372470Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.372143Z"
     }
    },
    "outputs": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "761e8c2c",
+   "id": "18103d0c",
    "metadata": {},
    "source": [
     "### Realize from a `{magnitude, units}` dict"
@@ -132,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "4a9ad538",
+   "id": "7a52c2db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.066254Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.066212Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.069213Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.068932Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.373573Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.373525Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.376701Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.376382Z"
     }
    },
    "outputs": [
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "80465e9a",
+   "id": "ce0cc948",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.070179Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.070134Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.071768Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.071476Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.377552Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.377502Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.379080Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.378802Z"
     }
    },
    "outputs": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23a6ebf8",
+   "id": "d03463a2",
    "metadata": {},
    "source": [
     "### Realize from a bare numeric (uses the schema's units)"
@@ -206,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5f7e2761",
+   "id": "7f750b57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.072683Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.072642Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.074484Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.074175Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.379948Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.379899Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.381892Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.381575Z"
     }
    },
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56b1d73d",
+   "id": "2a5e1554",
    "metadata": {},
    "source": [
     "### Realize from a parseable string"
@@ -249,13 +249,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "36650a1d",
+   "id": "5b810046",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.075454Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.075400Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.077279Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.077029Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.382830Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.382785Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.384647Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.384369Z"
     }
    },
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61ae78ba",
+   "id": "f580e75e",
    "metadata": {},
    "source": [
     "### Unit-aware operations at runtime"
@@ -292,13 +292,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "baf7c9b3",
+   "id": "bfff9afd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.078212Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.078169Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.080033Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.079689Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.385638Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.385576Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.387408Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.387155Z"
     }
    },
    "outputs": [
@@ -326,13 +326,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "525c2787",
+   "id": "b9e3fb2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.080851Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.080809Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.082433Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.082111Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.388271Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.388228Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.389808Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.389504Z"
     }
    },
    "outputs": [
@@ -354,13 +354,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "2b609a93",
+   "id": "0e1b2353",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.083285Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.083231Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.085019Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.084705Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.390680Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.390627Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.392531Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.392218Z"
     }
    },
    "outputs": [
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fa96386",
+   "id": "24625b29",
    "metadata": {},
    "source": [
     "### Serialize roundtrip"
@@ -396,13 +396,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "beda1e36",
+   "id": "a3a5fa25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.086015Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.085961Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.088384Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.088035Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.393422Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.393374Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.395723Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.395444Z"
     }
    },
    "outputs": [
@@ -425,13 +425,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "016d459f",
+   "id": "3cf4377a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.089246Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.089181Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.090906Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.090660Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.396608Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.396564Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.398348Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.398033Z"
     }
    },
    "outputs": [
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bdc51b4c",
+   "id": "288efa2a",
    "metadata": {},
    "source": [
     "## 2. `Number._units` — units as metadata\n",
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94ae11e6",
+   "id": "f51db617",
    "metadata": {},
    "source": [
     "### Defining a unit-annotated float schema"
@@ -472,13 +472,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "701f7e70",
+   "id": "b5e085d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.091786Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.091746Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.093556Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.093238Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.399295Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.399239Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.400966Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.400660Z"
     }
    },
    "outputs": [
@@ -501,13 +501,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "81fce304",
+   "id": "b8de3a6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.094416Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.094378Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.095926Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.095627Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.401832Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.401791Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.403310Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.403079Z"
     }
    },
    "outputs": [
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06968b2a",
+   "id": "d0586c8d",
    "metadata": {},
    "source": [
     "### The runtime value is a plain `float`"
@@ -537,13 +537,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "0beb4186",
+   "id": "2c406968",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.096755Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.096718Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.098327Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.098062Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.404076Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.404036Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.405675Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.405361Z"
     }
    },
    "outputs": [
@@ -565,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7384f8bf",
+   "id": "93752ed9",
    "metadata": {},
    "source": [
     "### Serialize is just the number"
@@ -574,13 +574,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "43d4d721",
+   "id": "bb9a1ab3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:51:11.099262Z",
-     "iopub.status.busy": "2026-05-12T20:51:11.099208Z",
-     "iopub.status.idle": "2026-05-12T20:51:11.100867Z",
-     "shell.execute_reply": "2026-05-12T20:51:11.100639Z"
+     "iopub.execute_input": "2026-05-12T20:53:03.406571Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.406528Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.408267Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.408026Z"
     }
    },
    "outputs": [
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "293f30fe",
+   "id": "218854e3",
    "metadata": {},
    "source": [
     "### When to use which\n",
@@ -612,6 +612,187 @@
     "| `Quantity`      | `pint.Quantity`   | the value itself   | unit-safe arithmetic / introspection at runtime     |\n",
     "\n",
     "`_units` is the right default for high-throughput numerics — no per-value pint overhead, and unit-aware wiring (Section 3) still works. Reach for `Quantity` when you need `.to()` or unit-checked arithmetic on individual values.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a15a764",
+   "metadata": {},
+   "source": [
+    "## 3. Unit conversion across wires\n",
+    "\n",
+    "When a state's schema declares `_units` and a port's schema declares a *different* `_units`, `bigraph-schema` doesn't silently mismatch — it computes a scalar conversion factor at compile time (using `pint`) and applies it during view/projection. The relevant logic is `Core._compute_unit_scale` in `bigraph_schema/core.py`.\n",
+    "\n",
+    "You can call it directly to see what happens for a given pair of units.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5b7596",
+   "metadata": {},
+   "source": [
+    "### Compatible units: a real scale factor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "db197e60",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:53:03.409274Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.409229Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.410958Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.410717Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1e-15"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core._compute_unit_scale('fg', 'g')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "32f4cc5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:53:03.411757Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.411714Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.413356Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.413106Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.001"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core._compute_unit_scale('mmol/L', 'mol/L')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ee75a9b",
+   "metadata": {},
+   "source": [
+    "### No-op cases\n",
+    "\n",
+    "`_compute_unit_scale` returns `1.0` (a true pass-through) in three cases:\n",
+    "\n",
+    "- one side has no unit declared (`''`)\n",
+    "- the units match exactly\n",
+    "- one side is `'dimensionless'`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f947476c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:53:03.414153Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.414112Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.415728Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.415416Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.0, 1.0, 1.0)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core._compute_unit_scale('', 'g'), core._compute_unit_scale('g', 'g'), core._compute_unit_scale('dimensionless', 'g')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec47be06",
+   "metadata": {},
+   "source": [
+    "### Incompatible units raise\n",
+    "\n",
+    "Asking pint to convert `fg` to `mol` is meaningless; the call raises. (In wire resolution this is caught and falls back to `1.0`, but it's intended to surface as a wire validation error — see the docstring in `core.py`.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "35b33c8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:53:03.416519Z",
+     "iopub.status.busy": "2026-05-12T20:53:03.416477Z",
+     "iopub.status.idle": "2026-05-12T20:53:03.418023Z",
+     "shell.execute_reply": "2026-05-12T20:53:03.417746Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DimensionalityError Cannot convert from 'femtogram' ([mass]) to 'mole' ([substance])\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    core._compute_unit_scale('fg', 'mol')\n",
+    "except Exception as exc:\n",
+    "    print(type(exc).__name__, exc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54a03d1b",
+   "metadata": {},
+   "source": [
+    "### How this plays out in a schema\n",
+    "\n",
+    "Picture a composite where a state at path `x` is stored in `fg` and a process reads it through a port declared in `g`:\n",
+    "\n",
+    "```python\n",
+    "schema = {\n",
+    "    'x': {'_type': 'float', '_units': 'fg'},\n",
+    "    'proc': {\n",
+    "        '_type': 'process',\n",
+    "        'inputs': {'mass': {'_type': 'float', '_units': 'g'}},\n",
+    "        ...\n",
+    "    },\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "When the wire from `proc.inputs.mass` resolves down to `x`, `bigraph-schema` computes `1e-15` once and caches it. Each view of the port multiplies the underlying `float` by `1e-15` so the process always sees grams, while storage stays in femtograms.\n",
+    "\n",
+    "The full machinery — `_collect_view_scales`, `view`, `project`, `apply` — is internal to `Core` and is exercised end-to-end in [`process-bigraph`](https://github.com/vivarium-collective/process-bigraph). For this notebook we stop at showing the scale computation itself.\n"
    ]
   }
  ],

--- a/notebooks/units.ipynb
+++ b/notebooks/units.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b1517be9",
+   "id": "54efcad2",
    "metadata": {},
    "source": [
     "# Units in `bigraph-schema`\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8122dbd4",
+   "id": "4daa2787",
    "metadata": {},
    "source": [
     "## Setup"
@@ -28,13 +28,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2d174071",
+   "id": "b99d3f75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.004090Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.003949Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.402477Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.401976Z"
+     "iopub.execute_input": "2026-05-12T20:51:10.655089Z",
+     "iopub.status.busy": "2026-05-12T20:51:10.654814Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.053477Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.053089Z"
     }
    },
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4251af0",
+   "id": "589e8c2f",
    "metadata": {},
    "source": [
     "## 1. `Quantity` — units carried at runtime\n",
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff14b6dd",
+   "id": "2660a511",
    "metadata": {},
    "source": [
     "### Defining a quantity schema"
@@ -64,13 +64,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6de55cf7",
+   "id": "e09d7f95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.403907Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.403822Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.409146Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.408810Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.054903Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.054815Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.060233Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.059935Z"
     }
    },
    "outputs": [
@@ -96,13 +96,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "43b7b5d4",
+   "id": "b63b025d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.410152Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.410101Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.413951Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.413693Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.061331Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.061287Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.065177Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.064904Z"
     }
    },
    "outputs": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ab3fa0f",
+   "id": "761e8c2c",
    "metadata": {},
    "source": [
     "### Realize from a `{magnitude, units}` dict"
@@ -132,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "061daffa",
+   "id": "4a9ad538",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.415056Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.415008Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.418037Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.417750Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.066254Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.066212Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.069213Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.068932Z"
     }
    },
    "outputs": [
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "be179d16",
+   "id": "80465e9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.418941Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.418894Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.420539Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.420288Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.070179Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.070134Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.071768Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.071476Z"
     }
    },
    "outputs": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93d58023",
+   "id": "23a6ebf8",
    "metadata": {},
    "source": [
     "### Realize from a bare numeric (uses the schema's units)"
@@ -206,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "15aed47a",
+   "id": "5f7e2761",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.421410Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.421368Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.423049Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.422734Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.072683Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.072642Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.074484Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.074175Z"
     }
    },
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2afe54b1",
+   "id": "56b1d73d",
    "metadata": {},
    "source": [
     "### Realize from a parseable string"
@@ -249,13 +249,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4a89c865",
+   "id": "36650a1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.424069Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.424014Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.425816Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.425561Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.075454Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.075400Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.077279Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.077029Z"
     }
    },
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f907b2e9",
+   "id": "61ae78ba",
    "metadata": {},
    "source": [
     "### Unit-aware operations at runtime"
@@ -292,13 +292,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "58083104",
+   "id": "baf7c9b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.426675Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.426635Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.428491Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.428168Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.078212Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.078169Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.080033Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.079689Z"
     }
    },
    "outputs": [
@@ -326,13 +326,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7bfee4c9",
+   "id": "525c2787",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.429311Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.429271Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.430764Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.430499Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.080851Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.080809Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.082433Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.082111Z"
     }
    },
    "outputs": [
@@ -354,13 +354,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "29b55b3e",
+   "id": "2b609a93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.431604Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.431562Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.433367Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.433040Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.083285Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.083231Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.085019Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.084705Z"
     }
    },
    "outputs": [
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53095b0e",
+   "id": "5fa96386",
    "metadata": {},
    "source": [
     "### Serialize roundtrip"
@@ -396,13 +396,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c62219bf",
+   "id": "beda1e36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.434298Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.434244Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.436751Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.436426Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.086015Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.085961Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.088384Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.088035Z"
     }
    },
    "outputs": [
@@ -425,13 +425,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a407d2f8",
+   "id": "016d459f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:50:15.437550Z",
-     "iopub.status.busy": "2026-05-12T20:50:15.437499Z",
-     "iopub.status.idle": "2026-05-12T20:50:15.439118Z",
-     "shell.execute_reply": "2026-05-12T20:50:15.438865Z"
+     "iopub.execute_input": "2026-05-12T20:51:11.089246Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.089181Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.090906Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.090660Z"
     }
    },
    "outputs": [
@@ -449,6 +449,169 @@
    "source": [
     "_, q_back, _ = core.realize(quantity_schema, encoded)\n",
     "q_back == q\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdc51b4c",
+   "metadata": {},
+   "source": [
+    "## 2. `Number._units` — units as metadata\n",
+    "\n",
+    "Use `_units` on a numeric type when you want to record the unit but keep the runtime value as a plain `float` (or numpy array). The unit string lives **only on the schema** — at runtime the value has no awareness of its units.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ae11e6",
+   "metadata": {},
+   "source": [
+    "### Defining a unit-annotated float schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "701f7e70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:51:11.091786Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.091746Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.093556Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.093238Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float(_default=None, _units='mol/L', _bits=0)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "float_schema = core.access({'_type': 'float', '_units': 'mol/L'})\n",
+    "float_schema\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "81fce304",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:51:11.094416Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.094378Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.095926Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.095627Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'float[mol/L]'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core.render(float_schema)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06968b2a",
+   "metadata": {},
+   "source": [
+    "### The runtime value is a plain `float`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0beb4186",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:51:11.096755Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.096718Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.098327Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.098062Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2.5, 'float')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, x, _ = core.realize(float_schema, 2.5)\n",
+    "x, type(x).__name__\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7384f8bf",
+   "metadata": {},
+   "source": [
+    "### Serialize is just the number"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "43d4d721",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:51:11.099262Z",
+     "iopub.status.busy": "2026-05-12T20:51:11.099208Z",
+     "iopub.status.idle": "2026-05-12T20:51:11.100867Z",
+     "shell.execute_reply": "2026-05-12T20:51:11.100639Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.5"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core.serialize(float_schema, x)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "293f30fe",
+   "metadata": {},
+   "source": [
+    "### When to use which\n",
+    "\n",
+    "| Approach        | Runtime value     | Unit info lives in | Use when                                            |\n",
+    "|-----------------|-------------------|--------------------|-----------------------------------------------------|\n",
+    "| `Number._units` | plain `float`     | schema annotation  | hot numerical paths; downstream code expects floats |\n",
+    "| `Quantity`      | `pint.Quantity`   | the value itself   | unit-safe arithmetic / introspection at runtime     |\n",
+    "\n",
+    "`_units` is the right default for high-throughput numerics — no per-value pint overhead, and unit-aware wiring (Section 3) still works. Reach for `Quantity` when you need `.to()` or unit-checked arithmetic on individual values.\n"
    ]
   }
  ],

--- a/notebooks/units.ipynb
+++ b/notebooks/units.ipynb
@@ -1,0 +1,476 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1517be9",
+   "metadata": {},
+   "source": [
+    "# Units in `bigraph-schema`\n",
+    "\n",
+    "`bigraph-schema` ships two complementary mechanisms for working with physical units:\n",
+    "\n",
+    "1. **`Quantity`** — the runtime value carries its units alongside its magnitude (backed by [`pint`](https://pint.readthedocs.io/)). You can call `.to(other_unit)`, do unit-safe arithmetic, and inspect `.dimensionality` at runtime.\n",
+    "2. **`Number._units`** — a schema-level annotation. The runtime value is a plain `float`; the unit string lives only on the schema.\n",
+    "\n",
+    "A third feature ties them together: when a state's schema declares `_units` and connects to a port that declares a different `_units`, `bigraph-schema` computes a scalar conversion factor at compile time so the value seen through the port is in the port's units.\n",
+    "\n",
+    "This notebook walks through each of these.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8122dbd4",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2d174071",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.004090Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.003949Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.402477Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.401976Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from bigraph_schema import allocate_core\n",
+    "core = allocate_core()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4251af0",
+   "metadata": {},
+   "source": [
+    "## 1. `Quantity` — units carried at runtime\n",
+    "\n",
+    "Use `'quantity'` when you want unit-aware arithmetic and conversion on the value itself. `realize` accepts several encodings; `serialize` always produces `{units, magnitude}`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff14b6dd",
+   "metadata": {},
+   "source": [
+    "### Defining a quantity schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6de55cf7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.403907Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.403822Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.409146Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.408810Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quantity(_default=None, units={'mol': 1, 'L': -1}, magnitude=Float(_default=None, _units='', _bits=0))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "quantity_schema = core.access({\n",
+    "    '_type': 'quantity',\n",
+    "    'units': {'mol': 1, 'L': -1},\n",
+    "})\n",
+    "quantity_schema\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "43b7b5d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.410152Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.410101Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.413951Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.413693Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_type': 'quantity', 'units': {'mol': 1, 'L': -1}, 'magnitude': 'float'}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "core.render(quantity_schema)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ab3fa0f",
+   "metadata": {},
+   "source": [
+    "### Realize from a `{magnitude, units}` dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "061daffa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.415056Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.415008Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.418037Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.417750Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "2.0 mol/L"
+      ],
+      "text/latex": [
+       "$2.0\\ \\frac{\\mathrm{mol}}{\\mathrm{L}}$"
+      ],
+      "text/plain": [
+       "<Quantity(2.0, 'mol / L')>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, q, _ = core.realize(\n",
+    "    quantity_schema,\n",
+    "    {'magnitude': 2.0, 'units': {'mol': 1, 'L': -1}},\n",
+    ")\n",
+    "q\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "be179d16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.418941Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.418894Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.420539Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.420288Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Quantity', 2.0, 'mol / L')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(q).__name__, q.magnitude, str(q.units)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93d58023",
+   "metadata": {},
+   "source": [
+    "### Realize from a bare numeric (uses the schema's units)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "15aed47a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.421410Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.421368Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.423049Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.422734Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "5.0 mol/L"
+      ],
+      "text/latex": [
+       "$5.0\\ \\frac{\\mathrm{mol}}{\\mathrm{L}}$"
+      ],
+      "text/plain": [
+       "<Quantity(5.0, 'mol / L')>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, q_bare, _ = core.realize(quantity_schema, 5.0)\n",
+    "q_bare\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2afe54b1",
+   "metadata": {},
+   "source": [
+    "### Realize from a parseable string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4a89c865",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.424069Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.424014Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.425816Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.425561Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "2.1 millimolar"
+      ],
+      "text/latex": [
+       "$2.1\\ \\mathrm{millimolar}$"
+      ],
+      "text/plain": [
+       "<Quantity(2.1, 'millimolar')>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, q_str, _ = core.realize(quantity_schema, '2.1 millimolar')\n",
+    "q_str\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f907b2e9",
+   "metadata": {},
+   "source": [
+    "### Unit-aware operations at runtime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "58083104",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.426675Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.426635Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.428491Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.428168Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "2000.0 millimole/liter"
+      ],
+      "text/latex": [
+       "$2000.0\\ \\frac{\\mathrm{millimole}}{\\mathrm{liter}}$"
+      ],
+      "text/plain": [
+       "<Quantity(2000.0, 'millimole / liter')>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q.to('mmol/L')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7bfee4c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.429311Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.429271Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.430764Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.430499Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<UnitsContainer({'[length]': -3, '[substance]': 1})>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q.dimensionality\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "29b55b3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.431604Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.431562Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.433367Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.433040Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "6.0 mole/liter"
+      ],
+      "text/latex": [
+       "$6.0\\ \\frac{\\mathrm{mole}}{\\mathrm{liter}}$"
+      ],
+      "text/plain": [
+       "<Quantity(6.0, 'mole / liter')>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(q * 3).to('mol/L')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53095b0e",
+   "metadata": {},
+   "source": [
+    "### Serialize roundtrip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c62219bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.434298Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.434244Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.436751Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.436426Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'units': {'mol': 1, 'L': -1}, 'magnitude': 2.0}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "encoded = core.serialize(quantity_schema, q)\n",
+    "encoded\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a407d2f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T20:50:15.437550Z",
+     "iopub.status.busy": "2026-05-12T20:50:15.437499Z",
+     "iopub.status.idle": "2026-05-12T20:50:15.439118Z",
+     "shell.execute_reply": "2026-05-12T20:50:15.438865Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, q_back, _ = core.realize(quantity_schema, encoded)\n",
+    "q_back == q\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/units.ipynb
+++ b/notebooks/units.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ca7527eb",
+   "id": "8c24542a",
    "metadata": {},
    "source": [
     "# Units in `bigraph-schema`\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "286dc8dc",
+   "id": "d41222f3",
    "metadata": {},
    "source": [
     "## Setup"
@@ -28,13 +28,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "bb0e652b",
+   "id": "d25edce0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:02.948481Z",
-     "iopub.status.busy": "2026-05-12T20:53:02.948383Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.360238Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.359800Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.405616Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.405495Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.840487Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.840029Z"
     }
    },
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72d8eda9",
+   "id": "a8f27b5a",
    "metadata": {},
    "source": [
     "## 1. `Quantity` — units carried at runtime\n",
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee8ac376",
+   "id": "3775b2ef",
    "metadata": {},
    "source": [
     "### Defining a quantity schema"
@@ -64,13 +64,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2e4dc5fc",
+   "id": "688cb7fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.361590Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.361509Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.367455Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.367066Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.841859Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.841780Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.847286Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.846933Z"
     }
    },
    "outputs": [
@@ -96,13 +96,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4d1333d1",
+   "id": "e54c61fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.368417Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.368367Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.372470Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.372143Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.848283Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.848232Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.852159Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.851819Z"
     }
    },
    "outputs": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18103d0c",
+   "id": "957d268b",
    "metadata": {},
    "source": [
     "### Realize from a `{magnitude, units}` dict"
@@ -132,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7a52c2db",
+   "id": "d74826e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.373573Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.373525Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.376701Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.376382Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.853260Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.853210Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.856237Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.855957Z"
     }
    },
    "outputs": [
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ce0cc948",
+   "id": "bc59aa6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.377552Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.377502Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.379080Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.378802Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.857182Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.857137Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.858810Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.858480Z"
     }
    },
    "outputs": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d03463a2",
+   "id": "fc883948",
    "metadata": {},
    "source": [
     "### Realize from a bare numeric (uses the schema's units)"
@@ -206,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7f750b57",
+   "id": "149efcae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.379948Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.379899Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.381892Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.381575Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.859754Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.859703Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.861535Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.861229Z"
     }
    },
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a5e1554",
+   "id": "4cd53585",
    "metadata": {},
    "source": [
     "### Realize from a parseable string"
@@ -249,13 +249,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "5b810046",
+   "id": "5b8679c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.382830Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.382785Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.384647Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.384369Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.862543Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.862494Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.864332Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.864069Z"
     }
    },
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f580e75e",
+   "id": "a0ea9b8a",
    "metadata": {},
    "source": [
     "### Unit-aware operations at runtime"
@@ -292,13 +292,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "bfff9afd",
+   "id": "5d9d334f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.385638Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.385576Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.387408Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.387155Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.865230Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.865181Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.866987Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.866700Z"
     }
    },
    "outputs": [
@@ -326,13 +326,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b9e3fb2e",
+   "id": "ffa74c8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.388271Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.388228Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.389808Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.389504Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.867922Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.867884Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.869423Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.869189Z"
     }
    },
    "outputs": [
@@ -354,13 +354,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0e1b2353",
+   "id": "711ef33b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.390680Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.390627Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.392531Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.392218Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.870353Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.870309Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.872135Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.871797Z"
     }
    },
    "outputs": [
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24625b29",
+   "id": "5103fa53",
    "metadata": {},
    "source": [
     "### Serialize roundtrip"
@@ -396,13 +396,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a3a5fa25",
+   "id": "b0466b8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.393422Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.393374Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.395723Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.395444Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.873000Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.872960Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.875395Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.875080Z"
     }
    },
    "outputs": [
@@ -425,13 +425,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3cf4377a",
+   "id": "f65fee67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.396608Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.396564Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.398348Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.398033Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.876414Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.876366Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.878031Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.877722Z"
     }
    },
    "outputs": [
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "288efa2a",
+   "id": "ad36ce68",
    "metadata": {},
    "source": [
     "## 2. `Number._units` — units as metadata\n",
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f51db617",
+   "id": "e8283b5e",
    "metadata": {},
    "source": [
     "### Defining a unit-annotated float schema"
@@ -472,13 +472,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b5e085d3",
+   "id": "1bf5dfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.399295Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.399239Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.400966Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.400660Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.878947Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.878893Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.880563Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.880276Z"
     }
    },
    "outputs": [
@@ -501,13 +501,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b8de3a6c",
+   "id": "1cb12078",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.401832Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.401791Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.403310Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.403079Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.881427Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.881390Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.882926Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.882685Z"
     }
    },
    "outputs": [
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0586c8d",
+   "id": "ae6768e0",
    "metadata": {},
    "source": [
     "### The runtime value is a plain `float`"
@@ -537,13 +537,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "2c406968",
+   "id": "a93404b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.404076Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.404036Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.405675Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.405361Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.883756Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.883717Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.885413Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.885081Z"
     }
    },
    "outputs": [
@@ -565,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93752ed9",
+   "id": "6777e4f1",
    "metadata": {},
    "source": [
     "### Serialize is just the number"
@@ -574,13 +574,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "bb9a1ab3",
+   "id": "cfc1819b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.406571Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.406528Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.408267Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.408026Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.886301Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.886264Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.887927Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.887688Z"
     }
    },
    "outputs": [
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "218854e3",
+   "id": "5734b594",
    "metadata": {},
    "source": [
     "### When to use which\n",
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a15a764",
+   "id": "bb842a60",
    "metadata": {},
    "source": [
     "## 3. Unit conversion across wires\n",
@@ -628,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c5b7596",
+   "id": "e1e18c70",
    "metadata": {},
    "source": [
     "### Compatible units: a real scale factor"
@@ -637,13 +637,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "db197e60",
+   "id": "9f04fb74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.409274Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.409229Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.410958Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.410717Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.888796Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.888743Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.890357Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.890112Z"
     }
    },
    "outputs": [
@@ -665,13 +665,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "32f4cc5b",
+   "id": "3481733f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.411757Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.411714Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.413356Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.413106Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.891210Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.891172Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.892828Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.892572Z"
     }
    },
    "outputs": [
@@ -692,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ee75a9b",
+   "id": "d42c2282",
    "metadata": {},
    "source": [
     "### No-op cases\n",
@@ -707,13 +707,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "f947476c",
+   "id": "0e41d3a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.414153Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.414112Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.415728Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.415416Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.893652Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.893611Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.895279Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.894946Z"
     }
    },
    "outputs": [
@@ -734,7 +734,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec47be06",
+   "id": "f8dbab55",
    "metadata": {},
    "source": [
     "### Incompatible units raise\n",
@@ -745,13 +745,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "35b33c8c",
+   "id": "7230fc4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T20:53:03.416519Z",
-     "iopub.status.busy": "2026-05-12T20:53:03.416477Z",
-     "iopub.status.idle": "2026-05-12T20:53:03.418023Z",
-     "shell.execute_reply": "2026-05-12T20:53:03.417746Z"
+     "iopub.execute_input": "2026-05-12T20:56:59.896139Z",
+     "iopub.status.busy": "2026-05-12T20:56:59.896092Z",
+     "iopub.status.idle": "2026-05-12T20:56:59.897668Z",
+     "shell.execute_reply": "2026-05-12T20:56:59.897408Z"
     }
    },
    "outputs": [
@@ -772,7 +772,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54a03d1b",
+   "id": "c7cabf49",
    "metadata": {},
    "source": [
     "### How this plays out in a schema\n",


### PR DESCRIPTION
## Summary
- New `notebooks/units.ipynb` covering `Quantity`, `Number._units`, and wire-level unit conversion (`Core._compute_unit_scale`).
- Extends `.github/workflows/notebook_to_html.yml` to render and publish `notebooks/units.html` to `gh-pages` alongside the existing tutorials.
- Adds a `Units Demo` badge near the top of `README.md` plus a third bullet under *Getting Started*.

Rendered HTML will appear at `https://vivarium-collective.github.io/bigraph-schema/notebooks/units.html` after this merges and the workflow runs.

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/units.ipynb` runs cleanly (verified locally)
- [x] `jupyter nbconvert --to html notebooks/units.ipynb` produces a valid HTML page (verified locally)
- [ ] After merge, confirm `notebook_to_html.yml` succeeds and `units.html` appears on `gh-pages`
- [ ] README badge resolves once the page is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)