### PR TITLE
Standardized formal description on Edge: describe() + description (1.4.0)

### DIFF
--- a/bigraph_schema/edge.py
+++ b/bigraph_schema/edge.py
@@ -6,6 +6,9 @@ Edge
 Base class for all edges in the bigraph schema.
 """
 
+import inspect
+
+
 def default_wires(schema):
     """
     Create default wiring for a schema by connecting each port to a store of the same name.
@@ -27,6 +30,12 @@ class Edge:
     """
 
     config_schema = {}
+
+    # Canonical formal description of this edge — a string (markdown / LaTeX) that
+    # states what the process/step computes (governing equations, assumptions).
+    # Override on subclasses. Tooling reads it via `describe()`, which falls back
+    # to the class docstring when this is left empty.
+    description = ''
 
     def __init__(self, config=None, core=None):
         """
@@ -134,5 +143,17 @@ class Edge:
             'inputs': self.inputs(),
             'outputs': self.outputs()
         }
+
+    def describe(self):
+        """
+        Return this edge's formal description.
+
+        Returns the ``description`` class attribute — the canonical formal
+        (mathematical) description of what this process/step computes. Falls
+        back to the class docstring when ``description`` is unset, so existing
+        edges still surface something. Subclasses should set ``description`` to
+        a string (markdown / LaTeX) for a precise, standardized description.
+        """
+        return self.description or inspect.getdoc(type(self)) or ''
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigraph-schema"
-version = "1.3.2"
+version = "1.4.0"
 description = "A serializable type schema for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
Adds a single, ecosystem-wide hook for a process/step's **formal description** on the `Edge` base class (inherited by every process-bigraph `Process`/`Step`), so tooling can stop scraping docstrings.

```python
class Edge:
    description = ''        # formal (mathematical) description — markdown / LaTeX / unicode
    def describe(self):
        return self.description or inspect.getdoc(type(self)) or ''
```

- **`description`** — set on a subclass to the canonical formal description (governing equations, assumptions).
- **`describe()`** — the standard accessor tooling calls; falls back to the class docstring when `description` is unset.

## Why
Today, consumers (bigraph-viz2 inspector, dashboards, viz transforms) read the class docstring, which is generic prose. This gives a dedicated, formal slot with a uniform accessor across the pbg ecosystem, while remaining **backward compatible** — default `description` is empty and `describe()` reproduces the prior docstring behavior.

## Notes
- Additive, non-breaking; no existing call sites change behavior.
- Downstream: bigraph-viz2 / viz transforms will read `edge.describe()`; processes opt in by setting `description`.
- Version 1.3.2 → 1.4.0 (new backward-compatible API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)