### PR TITLE
fix: allocate_core() returns fully isolated cores (P0 correctness)

### DIFF
--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -1619,24 +1619,58 @@ class Core:
 
 _cached_base_core = None
 
+
+def _isolated_copy(base):
+    """Return a Core that shares nothing mutable with ``base``.
+
+    ``copy.copy`` alone is a *shallow* copy: the new object would share
+    the very same ``registry``, ``link_registry``, ``method_registry`` and
+    cache dicts as ``base``, so registering a type on one leaks into all
+    others. Here we shallow-copy the object (preserving cheaply-derived
+    state like ``packages_distributions``) and then give the copy its own
+    registry containers plus fresh, empty per-instance caches.
+
+    The copy depth is deliberately container-level, not deep: registry
+    *entries* are immutable schema nodes/dicts, so duplicating the dicts
+    that hold them is enough to prevent key-level leakage between cores
+    without the cost of deep-copying every schema.
+    """
+    import copy
+    clone = copy.copy(base)
+    clone.registry = dict(base.registry)
+    clone.link_registry = dict(base.link_registry)
+    clone.method_registry = dict(base.method_registry)
+    # Fresh, empty per-instance caches so warm entries (and the id-keyed
+    # witnesses they hold) never bleed between independently-allocated cores.
+    clone._access_cache = collections.OrderedDict()
+    clone._access_string_cache = {}
+    clone._link_cache = {}
+    clone._resolve_cache = collections.OrderedDict()
+    clone._promote_cache = collections.OrderedDict()
+    # The parse visitor closes over its owning core; rebind it to the clone.
+    clone.parse_visitor = CoreVisitor(clone)
+    return clone
+
+
 def allocate_core(top=None):
     """Allocate a new Core with all discovered packages.
 
-    The base core (without ``top``) is cached after the first call
-    to avoid repeated expensive package discovery. Each call returns
-    a fresh copy so callers can register additional types independently.
+    The base core (without ``top``) is built once and cached to avoid
+    repeated expensive package discovery. Each call returns an *isolated*
+    copy: it shares no mutable state with any other allocated core, so
+    types/links/methods registered on one core never leak into another,
+    while the base types from discovery are present on every copy. See
+    :func:`_isolated_copy` for the (container-level) copy semantics.
     """
     global _cached_base_core
     if top is None and _cached_base_core is not None:
-        import copy
-        return copy.copy(_cached_base_core)
+        return _isolated_copy(_cached_base_core)
 
     core = Core(BASE_TYPES)
     core = discover_packages(core, top)
 
     if top is None:
         _cached_base_core = core
-        import copy
-        return copy.copy(core)
+        return _isolated_copy(core)
 
     return core

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,42 @@ def core():
     return allocate_core()
 
 
+def test_allocate_core_isolation():
+    """Two allocate_core() instances must not share registry mutations.
+
+    Registering a type/link/method on one core must not be visible on a
+    separately-allocated core, while both must still carry the base types
+    discovered when the cached base was built.
+    """
+    a = allocate_core()
+    b = allocate_core()
+
+    # Mutable containers and caches are distinct objects per instance.
+    assert a.registry is not b.registry
+    assert a.link_registry is not b.link_registry
+    assert a.method_registry is not b.method_registry
+    assert a._access_cache is not b._access_cache
+    assert a._resolve_cache is not b._resolve_cache
+    assert a._promote_cache is not b._promote_cache
+
+    # Both copies carry the shared base types.
+    assert 'float' in a.registry
+    assert 'float' in b.registry
+
+    # Mutating one must not leak into the other.
+    a.register_type('zzz_isolation_probe', 'float')
+    assert 'zzz_isolation_probe' in a.registry
+    assert 'zzz_isolation_probe' not in b.registry
+
+    a.register_link('zzz_isolation_link', Edge)
+    assert 'zzz_isolation_link' in a.link_registry
+    assert 'zzz_isolation_link' not in b.link_registry
+
+    a.register_method('zzz_isolation_method', lambda core, *args, **kw: None)
+    assert 'zzz_isolation_method' in a.method_registry
+    assert 'zzz_isolation_method' not in b.method_registry
+
+
 
 # test data ----------------------------
 


### PR DESCRIPTION
## P0 — core registry isolation

`allocate_core()` returned a **shallow** `copy.copy` of a cached base core, so every "independent" core shared the same `registry`, `link_registry`, `method_registry`, and caches. Registering a type on one core leaked into all others (verified at runtime: `a.registry is b.registry`). The docstring claimed isolation.

**Fix:** each `allocate_core()` now gets its own registry/link/method dicts (container-level copy — schema entries are immutable, so no deep copy needed) and fresh empty caches. The base core is still built once (discovery cost unchanged).

**Downstream audit:** grepped process-bigraph, pbg-superpowers, v2ecoli — every consumer uses the safe per-core `allocate_core() → register_types(core)` pattern. Nothing relied on the shared registry, so isolation breaks nothing.

**Verification:** bigraph-schema 1040 pass (incl. new `test_allocate_core_isolation`); process-bigraph 45 pass / 15 slow-skip (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)