### PR TITLE
release: bigraph-schema 1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigraph-schema"
-version = "1.4.1"
+version = "1.4.2"
 description = "A serializable type schema for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump 1.4.1 → 1.4.2 to release the changes merged since v1.4.1: allocate_core isolation fix (#163/#164), CoreVisitor → parse.py (#165), and the bundle Parquet layer inversion (#166). Internal/refactor only, no public API change. Tag `v1.4.2` after merge publishes to PyPI.