### PR TITLE
fix(discover): harden package walk against non-ImportError import failures + skip test modules

### DIFF
--- a/bigraph_schema/package/discover.py
+++ b/bigraph_schema/package/discover.py
@@ -8,6 +8,19 @@ from bigraph_schema import Edge
 from bigraph_schema.schema import Node
 
 
+# Submodule / subpackage names that core discovery must never import.
+# Test scaffolding routinely pulls in heavy, test-only optional
+# dependencies (e.g. fastapi/starlette ``TestClient`` needs httpx) and
+# registers no Processes/Steps/Types worth discovering. Importing it can
+# raise arbitrary exceptions and abort the whole walk, so skip it up front.
+SKIP_SUBMODULES = frozenset({"tests", "testing"})
+
+
+def _should_skip_submodule(subname: str) -> bool:
+    """True for test scaffolding that must be excluded from the walk."""
+    return subname in SKIP_SUBMODULES or subname.startswith("test_")
+
+
 def find_edges(mapping, module_name=None):
     discovered = []
     for _, cls in mapping:
@@ -83,6 +96,12 @@ def recursive_dynamic_import(
         try:
             module = importlib.import_module(adjusted)
 
+        except (KeyboardInterrupt, SystemExit):
+            # Never swallow interpreter-control signals: a Ctrl-C or an
+            # intentional sys.exit() raised at import time must propagate
+            # so discovery can't trap a deliberate interpreter exit.
+            raise
+
         except ImportError as e:
             # Catch both ModuleNotFoundError (the target itself is missing)
             # and ImportError (the target exists but a dep inside it failed
@@ -97,6 +116,20 @@ def recursive_dynamic_import(
                 print(f"module `{adjusted}` not found during dynamic import")
             return core, edges, types, visited
 
+        except Exception as e:
+            # A submodule can fail at import time with an exception that is
+            # NOT an ImportError — e.g. starlette raising RuntimeError when
+            # an optional test dependency (httpx) is absent, or an OSError
+            # from a module that touches the filesystem at import. One broken
+            # or optional submodule must never abort the entire package walk,
+            # so log a clear warning and skip it. KeyboardInterrupt/SystemExit
+            # are BaseException subclasses and are intentionally not caught
+            # here (handled above), so Ctrl-C still works.
+            print(
+                f"skipping `{adjusted}` "
+                f"({type(e).__name__} raised at import: {e})")
+            return core, edges, types, visited
+
     # Allow module to register types into core
     if hasattr(module, "register_types"):
         core = module.register_types(core)
@@ -108,6 +141,9 @@ def recursive_dynamic_import(
     # Recurse into submodules if this is a package
     if hasattr(module, "__path__"):
         for _, subname, _ in pkgutil.iter_modules(module.__path__):
+            # Never descend into test scaffolding (test_*, tests, testing).
+            if _should_skip_submodule(subname):
+                continue
             submod = f"{adjusted}.{subname}"
             core, sub_edges, sub_types, visited = recursive_dynamic_import(
                 core, submod, visited=visited)

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import numpy as np
@@ -8,6 +10,8 @@ from bigraph_schema.schema import (
     Float, String, Map, Tree, Link, Array, Overwrite, Node, Empty,
     Site, InnerName, OuterName, Interface)
 from bigraph_schema.methods import check, render, serialize, apply, reconcile
+from bigraph_schema.package.discover import (
+    recursive_dynamic_import, _should_skip_submodule)
 
 
 @pytest.fixture
@@ -2493,6 +2497,92 @@ def test_interfaces_container_traversal(core):
     inner4, _ = interfaces(schema4)
     assert len(inner4._places) == 1
     assert inner4._places[0][0] == ('hier', '*')
+
+
+def _build_fake_discovery_package(root):
+    """Materialize a fake installable package tree on disk for the
+    package-discovery walk to traverse.
+
+    Layout (under ``root``)::
+
+        fake_disco_pkg/__init__.py        # registers a sentinel marker
+        fake_disco_pkg/boom.py            # raises RuntimeError at import
+        fake_disco_pkg/good.py            # imports cleanly
+        fake_disco_pkg/test_scaffold.py   # must NOT be imported (test_*)
+        fake_disco_pkg/testing/__init__.py# must NOT be imported (testing)
+
+    The ``boom`` module mimics the observed failure mode (starlette
+    raising ``RuntimeError`` rather than ``ImportError`` when an optional
+    test dependency is missing). The ``test_scaffold``/``testing`` modules
+    raise on import too, so if the walk *did* import them the test would
+    fail loudly rather than silently.
+    """
+    pkg = root / "fake_disco_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "boom.py").write_text(
+        "raise RuntimeError('simulated optional-dep failure at import')\n")
+    (pkg / "good.py").write_text("VALUE = 1\n")
+    # If the discovery walk ever imports these, they explode — proving a
+    # regression in the test-scaffolding skip rule.
+    (pkg / "test_scaffold.py").write_text(
+        "raise AssertionError('test_* module must not be imported by walk')\n")
+    testing = pkg / "testing"
+    testing.mkdir()
+    (testing / "__init__.py").write_text(
+        "raise AssertionError('testing pkg must not be imported by walk')\n")
+
+
+def test_recursive_import_skips_runtime_error_module(tmp_path, capsys):
+    """A submodule raising a non-ImportError (RuntimeError) at import time
+    must be caught and skipped so the package walk completes — this is the
+    httpx2/starlette crash class that aborted ``build_core()`` downstream."""
+    _build_fake_discovery_package(tmp_path)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        core = allocate_core()
+        # Must NOT raise even though `boom` raises RuntimeError at import.
+        core, edges, types, visited = recursive_dynamic_import(
+            core, "fake_disco_pkg")
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "fake_disco_pkg" or name.startswith("fake_disco_pkg."):
+                del sys.modules[name]
+
+    out = capsys.readouterr().out
+    # (b) a clear warning was emitted naming the module and exception type.
+    assert "fake_disco_pkg.boom" in out
+    assert "RuntimeError" in out
+
+
+def test_recursive_import_skips_test_modules(tmp_path):
+    """The walk must never import test scaffolding (test_*, tests, testing).
+    Those fake modules raise on import, so reaching them would surface as an
+    error here; instead they should be silently skipped."""
+    _build_fake_discovery_package(tmp_path)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        core = allocate_core()
+        recursive_dynamic_import(core, "fake_disco_pkg")
+        # The good (non-test) submodule got imported; the test ones did not.
+        assert "fake_disco_pkg.good" in sys.modules
+        assert "fake_disco_pkg.testing" not in sys.modules
+        assert "fake_disco_pkg.test_scaffold" not in sys.modules
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "fake_disco_pkg" or name.startswith("fake_disco_pkg."):
+                del sys.modules[name]
+
+
+def test_should_skip_submodule_rules():
+    """Unit-level guard for the test-scaffolding skip predicate."""
+    assert _should_skip_submodule("tests")
+    assert _should_skip_submodule("testing")
+    assert _should_skip_submodule("test_e2e")
+    assert not _should_skip_submodule("processes")
+    assert not _should_skip_submodule("contest")  # not a prefix match
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem (Class B — eager-import discovery crash)

`process_bigraph.allocate_core()` → `discover_packages()` → `load_local_modules()` → `recursive_dynamic_import()` walks every installed process library and eagerly `importlib.import_module()`s every submodule to auto-register Processes/Steps/Types. This is exactly what every workspace's `build_core()` calls.

The import was wrapped only in `except ImportError`. A submodule that fails at import time with **any other exception** escaped the handler and aborted the entire discovery walk, hard-crashing `build_core()`.

Observed downstream (`chromosome-rep1`):

```
build_core() → allocate_core() → discover_packages() → load_local_modules()
  → recursive_dynamic_import()
  → import_module('vivarium_dashboard.testing.test_modular_tests_e2e')
  → from fastapi.testclient import TestClient
  → RuntimeError: The starlette.testclient module requires the httpx package to be installed.
```

`polars` optional-dep modules were skipped cleanly (they raise `ImportError`), but starlette raises **`RuntimeError`**, which escaped the trap.

## Fix (defense in depth, both in `bigraph_schema/package/discover.py`)

1. **Broaden the import-failure trap** in `recursive_dynamic_import`. The existing nicer "missing optional dep" message path for `ImportError` is preserved; a new `except Exception` fallback logs `module name + exception type + message` and skips, so one broken/optional submodule never aborts discovery. `KeyboardInterrupt`/`SystemExit` are `BaseException` subclasses and are **explicitly re-raised** (added `except (KeyboardInterrupt, SystemExit): raise` before the broad handler), so Ctrl-C and intentional `sys.exit()` still propagate.

2. **Exclude test scaffolding from the walk.** New `SKIP_SUBMODULES = {"tests", "testing"}` + `test_*` prefix check (`_should_skip_submodule`) applied in the `pkgutil.iter_modules` recursion. Core discovery should never import test modules. The crashing module matched this rule, so either fix alone prevents the crash.

## Tests

Added three regression tests in `tests.py`:
- `test_recursive_import_skips_runtime_error_module` — a fake subpackage whose submodule raises `RuntimeError` at import; asserts the walk completes without raising and a clear warning naming the module + `RuntimeError` is emitted.
- `test_recursive_import_skips_test_modules` — asserts `test_*`/`testing` submodules are **not** imported by the walk while the normal submodule is.
- `test_should_skip_submodule_rules` — unit guard for the skip predicate.

Full suite: **1056 passed** locally (`uv run pytest`), including the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)