### PR TITLE
feat(serialize): emit registered type NAME for type objects

### DIFF
--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -188,6 +188,17 @@ class Core:
             self.registry[key] = found
         # Invalidate access cache since type registry changed
         self._access_cache.pop(key, None)
+        # Record the reverse class -> name mapping so serialize.render() can emit
+        # this type's NAME (not a Python class repr) when a port declares it as a
+        # type OBJECT (e.g. a process whose inputs() returns InPlaceDict()).
+        try:
+            from bigraph_schema.methods.serialize import register_type_name
+            from bigraph_schema.schema import Node
+            cls = found if isinstance(found, type) else type(found)
+            if isinstance(cls, type) and issubclass(cls, Node):
+                register_type_name(cls, key)
+        except Exception:
+            pass
 
     def register_types(self, types):
         """Bulk register multiple type keys into the operation registry."""

--- a/bigraph_schema/methods/serialize.py
+++ b/bigraph_schema/methods/serialize.py
@@ -486,17 +486,42 @@ def render(schema: Node, defaults=False):
     return wrap_default(schema, subrender) if defaults else subrender
 
 
-# Reverse lookup: Node subclass -> registered type name
+# Reverse lookup: Node subclass -> registered type name. Seeded from BASE_TYPES,
+# and extended by the core as it registers further types (e.g. workspace types
+# like `inplace_dict`) via `register_type_name` — so render() can emit a name for
+# any registered type, not only the base set.
 _TYPE_NAME_CACHE = {}
+_BASE_SEEDED = False
+
+
+def _seed_base_types():
+    global _BASE_SEEDED
+    if _BASE_SEEDED:
+        return
+    from bigraph_schema.schema import BASE_TYPES
+    for name, type_cls in BASE_TYPES.items():
+        if isinstance(type_cls, type):
+            _TYPE_NAME_CACHE.setdefault(type_cls, name)
+    _BASE_SEEDED = True
+
+
+def register_type_name(cls, name):
+    """Record a ``Node`` subclass → its registered type name so ``render`` can
+    emit the name for types registered beyond BASE_TYPES. Prefer an explicit
+    registered name (e.g. ``inplace_dict``) over the class's own CamelCase name
+    (types are commonly auto-registered under ``__name__`` too, so first-wins
+    would otherwise keep ``InPlaceDict``)."""
+    if not isinstance(cls, type):
+        return
+    _seed_base_types()
+    existing = _TYPE_NAME_CACHE.get(cls)
+    if existing is None or (existing == cls.__name__ and name != cls.__name__):
+        _TYPE_NAME_CACHE[cls] = name
+
 
 def _node_type_name(cls):
     """Get the registered type name for a Node subclass, if any."""
-    if not _TYPE_NAME_CACHE:
-        # Build cache from BASE_TYPES
-        from bigraph_schema.schema import BASE_TYPES
-        for name, type_cls in BASE_TYPES.items():
-            if isinstance(type_cls, type):
-                _TYPE_NAME_CACHE[type_cls] = name
+    _seed_base_types()
     return _TYPE_NAME_CACHE.get(cls)
 
 @dispatch


### PR DESCRIPTION
`render(type_object)` now emits the registered type name (`inplace_dict`, `float`, `overwrite[node]`) instead of the Python class repr, by recording a reverse class→name mapping in `core.register_type` and seeding base types in `_node_type_name`. Fixes port-schema type objects rendering as `InPlaceDict(_default=None, _value=Node(...))` in the loom.

Tests: serialize + type suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)