### PR TITLE
fix(discover): walk all import packages for a dist (not last-wins)

### DIFF
--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -135,10 +135,16 @@ class Core:
             for key, values in importlib.metadata.packages_distributions().items()
             for value in values}
 
-        self.distributions_packages = {
-            value: key
-            for key, values in self.packages_distributions.items()
-            for value in values}
+        # dist -> LIST of its import packages. A single distribution can ship
+        # more than one import package (e.g. a real package plus a back-compat
+        # shim), so this must AGGREGATE, not last-wins-collapse to a single
+        # package — otherwise an empty shim can shadow the real package and its
+        # edges/types/visualizations are never discovered (bigraph-schema
+        # discover walks every package listed here).
+        self.distributions_packages = {}
+        for package, dists in self.packages_distributions.items():
+            for dist in dists:
+                self.distributions_packages.setdefault(dist, []).append(package)
 
         self.registry = {}
         self.link_registry = {}

--- a/bigraph_schema/package/discover.py
+++ b/bigraph_schema/package/discover.py
@@ -88,7 +88,23 @@ def recursive_dynamic_import(
         visited.add(adjusted)
 
     if isinstance(module, str):
-        adjusted = core.distributions_packages.get(module, module)
+        # A dist name can map to MORE THAN ONE import package (a real package
+        # plus a back-compat shim shipped in the same distribution). Walk EVERY
+        # package for the dist — otherwise an empty shim shadows the real
+        # package and its edges/types/visualizations are never discovered.
+        dist_packages = core.distributions_packages.get(module)
+        if dist_packages is not None:
+            for package in dist_packages:
+                if package in visited:
+                    continue
+                core, pkg_edges, pkg_types, visited = recursive_dynamic_import(
+                    core, package, visited=visited)
+                edges.extend(pkg_edges)
+                types.extend(pkg_types)
+            return core, edges, types, visited
+
+        # Not a known dist name -> treat as an import-package/module name.
+        adjusted = module
         if adjusted in visited:
             return core, edges, types, visited
         visited.add(adjusted)

--- a/tests/test_multi_package_dist_discovery.py
+++ b/tests/test_multi_package_dist_discovery.py
@@ -1,0 +1,39 @@
+"""A distribution can ship more than one import package (e.g. a real package
+plus a back-compat shim). Discovery must AGGREGATE all packages for a dist —
+not last-wins-collapse to a single one — else an empty shim can shadow the real
+package and its edges/types/visualizations are never discovered.
+
+Regression for the pbg-superpowers 0.16.0 case: the dist ships both
+``viva_superpowers`` (real) and ``pbg_superpowers`` (shim); last-wins could
+resolve the dist to the empty shim, so the real package's Demo* viz classes
+weren't discovered.
+"""
+import importlib.metadata
+
+from bigraph_schema import Core
+
+
+def test_multi_package_dist_aggregates_not_last_wins(monkeypatch):
+    # A dist ("multi-dist") that ships TWO import packages.
+    fake = {
+        "real_pkg": ["multi-dist"],
+        "shim_pkg": ["multi-dist"],
+        "bigraph_schema": ["bigraph-schema"],
+    }
+    monkeypatch.setattr(
+        importlib.metadata, "packages_distributions", lambda: fake)
+
+    core = Core({})
+
+    packages = core.distributions_packages["multi-dist"]
+    assert isinstance(packages, list)
+    # BOTH packages are present — not just the last-wins one.
+    assert set(packages) == {"real_pkg", "shim_pkg"}
+
+
+def test_distributions_packages_values_are_lists():
+    """Every dist maps to a list of its import packages."""
+    core = Core({})
+    assert all(isinstance(v, list) for v in core.distributions_packages.values())
+    # bigraph-schema is always present and maps to the bigraph_schema package.
+    assert "bigraph_schema" in core.distributions_packages.get("bigraph-schema", [])


### PR DESCRIPTION
## Root cause
`importlib.metadata.packages_distributions()` can map **multiple import packages to one distribution** — e.g. `pbg-superpowers 0.16.0` ships both `viva_superpowers` (real) and `pbg_superpowers` (back-compat shim). `Core.__init__` inverted that map **last-wins** (`{dist: package}`), so the `pbg-superpowers` dist could resolve to the **empty shim**, and `recursive_dynamic_import` never walked the real package → its edges/types/**visualization classes** were silently undiscovered.

This is the diagnosed blocker for the workbench `pbg → viva` rebrand (vivarium-workbench #572): after the import switch, workspace/default `Demo*` viz classes stopped being discovered.

## Fix
- `distributions_packages` now aggregates: `{dist: [packages]}` (not last-wins).
- `recursive_dynamic_import` walks **every** package for a dist.

## Tests
New `tests/test_multi_package_dist_discovery.py` (a two-package dist aggregates both, not last-wins). Full suite: 23 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)