### PR TITLE
chore: bump version to 1.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigraph-schema"
-version = "1.4.2"
+version = "1.4.3"
 description = "A serializable type schema for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Ships the multi-package-dist discovery fix (#171) so consumers can pull it (enables the pbg→viva rebrand's viz-class discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)