### PR TITLE
fix(discover): infinite recursion when a dist name equals its import-package name

### DIFF
--- a/bigraph_schema/package/discover.py
+++ b/bigraph_schema/package/discover.py
@@ -73,6 +73,7 @@ def recursive_dynamic_import(
     core,
     module,
     visited: Set[str] | None = None,
+    is_package: bool = False,
 ) -> tuple[object, List[tuple[str, Type[Edge]]], List[tuple[str, type]]]:
     if visited is None:
         visited = set()
@@ -92,18 +93,26 @@ def recursive_dynamic_import(
         # plus a back-compat shim shipped in the same distribution). Walk EVERY
         # package for the dist — otherwise an empty shim shadows the real
         # package and its edges/types/visualizations are never discovered.
-        dist_packages = core.distributions_packages.get(module)
-        if dist_packages is not None:
-            for package in dist_packages:
-                if package in visited:
-                    continue
-                core, pkg_edges, pkg_types, visited = recursive_dynamic_import(
-                    core, package, visited=visited)
-                edges.extend(pkg_edges)
-                types.extend(pkg_types)
-            return core, edges, types, visited
+        #
+        # `is_package` guards against the DIST-NAME == IMPORT-PACKAGE-NAME case
+        # (e.g. a dist `v2ecoli` whose import package is also `v2ecoli`): without
+        # it, recursing on that package name re-enters this dist branch and loops
+        # forever (RecursionError). Recursions from the dist loop below (and from
+        # the submodule walk) force `is_package=True` so the name is imported as a
+        # package, never re-interpreted as a dist.
+        if not is_package:
+            dist_packages = core.distributions_packages.get(module)
+            if dist_packages is not None:
+                for package in dist_packages:
+                    if package in visited:
+                        continue
+                    core, pkg_edges, pkg_types, visited = recursive_dynamic_import(
+                        core, package, visited=visited, is_package=True)
+                    edges.extend(pkg_edges)
+                    types.extend(pkg_types)
+                return core, edges, types, visited
 
-        # Not a known dist name -> treat as an import-package/module name.
+        # An import-package/module name -> import + walk it.
         adjusted = module
         if adjusted in visited:
             return core, edges, types, visited
@@ -162,7 +171,7 @@ def recursive_dynamic_import(
                 continue
             submod = f"{adjusted}.{subname}"
             core, sub_edges, sub_types, visited = recursive_dynamic_import(
-                core, submod, visited=visited)
+                core, submod, visited=visited, is_package=True)
             edges.extend(sub_edges)
             types.extend(sub_types)
 

--- a/tests/test_multi_package_dist_discovery.py
+++ b/tests/test_multi_package_dist_discovery.py
@@ -37,3 +37,27 @@ def test_distributions_packages_values_are_lists():
     assert all(isinstance(v, list) for v in core.distributions_packages.values())
     # bigraph-schema is always present and maps to the bigraph_schema package.
     assert "bigraph_schema" in core.distributions_packages.get("bigraph-schema", [])
+
+
+def test_dist_name_equal_package_name_does_not_recurse(monkeypatch):
+    """A dist whose NAME equals its import PACKAGE name (e.g. a dist ``v2ecoli``
+    whose import package is also ``v2ecoli``) must not recurse forever.
+
+    Regression: the multi-package walk recursed on each of a dist's packages;
+    when a package name equalled the dist name it re-entered the dist branch and
+    looped until ``RecursionError`` (~3000 frames). The ``is_package`` guard
+    imports such a name as a package instead of re-interpreting it as a dist.
+    """
+    import importlib.metadata
+    from bigraph_schema import Core
+    from bigraph_schema.package.discover import recursive_dynamic_import
+
+    fake = {"selfpkg": ["selfpkg"], "bigraph_schema": ["bigraph-schema"]}
+    monkeypatch.setattr(
+        importlib.metadata, "packages_distributions", lambda: fake)
+    core = Core({})
+
+    # Must terminate (the package import simply fails and is skipped),
+    # NOT raise RecursionError.
+    _core, _edges, _types, visited = recursive_dynamic_import(core, "selfpkg")
+    assert "selfpkg" in visited


### PR DESCRIPTION
## What happened
The #171 multi-package discovery walk recurses on each import package of a dist. But `recursive_dynamic_import` can't tell 'process this string as a dist' from 'process it as a package'. When a dist name **equals** an import-package name (e.g. the `v2ecoli` dist ships a `v2ecoli` package), recursing on that package re-enters the dist branch, which resolves the same dist again → infinite recursion (~3000 frames → `RecursionError` during composite building).

## Fix
Add an `is_package` flag. Recursions from the dist-package loop and the submodule walk pass `is_package=True`, so the name is imported as a package instead of being re-interpreted as a dist. #171's behavior (walk **all** of a dist's packages, incl. back-compat shims) is preserved.

Adds a regression test (`test_dist_name_equal_package_name_does_not_recurse`); existing discovery tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)