### PR TITLE
docs(spec): template/slot primitive (Layer 1 of framework-unification)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -380,11 +380,22 @@ reaction **matching** (a redex site captures sibling keys) — a different opera
   address + config, not ports) — `admits` no longer rejects every genuine filler.
 - **Done earlier:** cardinality reaction (§4.5), `build()` (§4.3).
 
-### In flight (queued Fable batch)
+### Done — Layer 1 complete (1130 tests, 0 failures)
 
-- **Address-injection** explicit tests (§4.6).
-- **Contract = face + amendments** (§4.7) — `describe_contract` to sites, `amend`
-  (`narrow`/`annotate`), `admits` via the contract.
+- **Address injection** (§4.6) — 5 tests of the abstract-process shape (fixed
+  face/config/wiring, only `address` open); conforming injections build to live
+  instances, non-conforming rejected naming the port. Fixed two further instances of
+  the address-bug root cause (declared *wires* were materialized as a `{port: path}`
+  dict and walked as a schema — every edge naming its own wiring was un-realizable on
+  `origin/main`).
+- **Contract = face + amendments** (§4.7) — `ProcessContract` absorbed it (two fields:
+  `face`, `amendments`); `core.describe_contract` universal (edge *or* site);
+  `amend`/`Amendment` with `narrow`/`annotate` (`extend` refused); `admits` routes
+  through `contract_of` + `contract_admits`. The **monotonicity law holds by
+  construction** — `narrow` may add required ports/predicates but **refuses to
+  redefine an existing port**, so a filler admissible after narrowing was admissible
+  before. (Noted tension: per-port *types* live on the face, per-port *prose* on
+  `ProcessContract.inputs`; kept separate so `annotate` cannot change admissibility.)
 
 ### Flagged, carried to Layer 2a (process-bigraph)
 

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -1,0 +1,355 @@
+# bigraph-schema `template` / `slot` primitive — design spec
+
+**Status:** Design (Layer 1 of the framework-unification stack)
+**Date:** 2026-07-30
+**Repo:** bigraph-schema (keystone — every layer above depends on this)
+**Umbrella:** `vivarium-workbench/docs/superpowers/specs/2026-07-29-framework-unification-design.md` (PR #676)
+**Depends on:** nothing upstream. **Consumed by:** process-bigraph (Study/Investigation composites), vivarium-workbench (templates → study docs), v2ecoli.
+
+---
+
+## 1. Goal
+
+Add a first-class **template**: a schema with **N named, typed slots** (holes).
+**Binding** the slots — supplying a filler per slot — produces a **concrete
+(ground) composite document**. A template must do **three** things:
+
+1. **Constrain the shape of what fits a slot.** A slot is not "any composite" — it
+   declares the **interface** (required inputs/outputs, and optionally an address
+   protocol) that a filler process/composite must conform to. This is *structural
+   typing over the bigraph*: only a process whose `interface()` matches may fill it.
+2. **Parameterize scalar config.** Ordinary value slots (`float`, `string`,
+   `map[...]`, …) — the generalization of `CompositeSpec.parameters`' flat `${name}`
+   substitution.
+3. **Parameterize structure (generative).** Some parameters change the *shape of
+   the generated document*, not just leaf values — e.g. the **number of process
+   instances** in a store, or the **number of store subtrees**. A cardinality slot
+   drives multiplicity of a marked body region, expanding it into N instances on
+   bind.
+
+Litmus test (the umbrella's "template study"): a template whose composite slot —
+constrained to processes with a given interface — binds a model-under-test into a
+standard analysis-flush sub-network, with a cardinality slot for `n_seeds` /
+`n_replicas`. Drop any conforming registered composite (`ecoli_baseline`,
+`viva_munk.biofilm`, `pbg_copasi.steady-state`) into the slot → a runnable study
+document, no code.
+
+---
+
+## 2. What already exists (grounding — do not rebuild)
+
+Verified against the current tree (`bigraph_schema/`):
+
+- **There is no `composite` / `process` / `step` type here.** The bigraph *is*
+  the schema dict (dict nesting = place graph; `Link` nodes = link graph). A
+  "composite document" is a nested-dict schema+state; **`Link`** (`schema.py:273`)
+  is the edge/process/step primitive (`_inputs`/`_outputs` port-type maps +
+  `inputs`/`outputs` wires). `Edge` (`edge.py:23`) is its Python side, declaring
+  ports via `inputs()`/`outputs()`.
+- **Typed holes already exist — the Milner `Site`.** `Site(Empty)`
+  (`schema.py:603`) is "a hole in the place graph — an open inner-face position."
+  `assembly.compose(outer, inner)` (`assembly.py:185`) **substitutes each `Site`
+  in `outer` with a root from `inner`** (`_set_at_path`) and wires matching port
+  names; `is_ground(schema)` (`assembly.py:163`) is True when **no Sites remain**.
+  `interfaces(schema)` (`assembly.py:59`) enumerates the open sites/names. This is
+  a *tested* "typed holes → fill → concrete document" pipeline
+  (`tests.py:test_compose_fills_sites`, 1578).
+- **Parameter machinery.** `align_parameters` (positional→named,
+  `handle_parameters.py:63`) then `reify_schema` (`core.access` each param +
+  `core.resolve` into the field, `handle_parameters.py:177`). Generic `Node`
+  binding zips a type's `_schema_keys` fields with positional params
+  (`handle_parameters.py:162`, `276`). Grammar supports `type[X,Y]`, named
+  `type[a:X|b:Y]`, and `type{default}` (`parse.py:35`).
+- **Type definition & registry.** A type is a `@dataclass` `Node` subclass whose
+  **`_schema_keys` frozenset declares its parameter fields** (`schema.py`, e.g.
+  `Map:227`), with `field(default_factory=...)` defaults; behavior is added via
+  plum `@dispatch` methods under `methods/` (`default`, `apply`, `realize`, …).
+  Register via `core.register_type(name, cls)` (`core.py:188`) or in `BASE_TYPES`
+  (`schema.py:690`).
+- **Fill / defaults.** `Core.fill(schema, state)` (`core.py:743`) = build defaults
+  (`default.py`) then layer state; `Core.realize` (`core.py:599`) decodes/fills;
+  `realize_link` (`realize.py:608`) instantiates edges and merges port schemas.
+- **Cross-package registration/discovery.** `discover_packages` (`discover.py:228`)
+  auto-scans every dist that depends on `bigraph-schema`; a downstream module
+  exposing `register_types(core) -> core` is invoked on import
+  (`discover.py:158`); `Node`/`Edge` subclasses are found by class scan.
+
+**Consequence:** ~80% of "template" is present. The genuinely new pieces are (a) a
+**named, type-constrained slot** (today's `Site` carries only a `_sort`, no name
+or fill-type constraint), and (b) a **multi-slot binding operation** that is a thin
+layer over `compose` + `reify`/`fill`.
+
+---
+
+## 3. The core design decision
+
+Two candidate mechanisms exist; the umbrella conflated them. This spec picks a
+**hybrid keyed on slot kind** — three kinds, matching the three goals in §1 — each
+reusing existing machinery:
+
+| Slot kind | Filler | Type constraint | Mechanism |
+|---|---|---|---|
+| **process / composite** (structural, shape-typed) | a bigraph subtree / registered composite whose `interface()` conforms | an **interface**: required `_inputs`/`_outputs` (`link[in,out]`) + optional address protocol | **`Site` + `assembly.compose`** to substitute the subtree; **interface conformance check** before/at bind |
+| **value** (scalar config) | a value or leaf schema | a value type (`float`, `int`, `string`, `map[...]`, `enum[...]`) | **`reify_schema` / `core.resolve`** into the slot position |
+| **cardinality** (generative) | an `int` (or small value) that sets a **count** | `int` with optional `range[...]` | **generative expansion**: the count drives multiplicity of a **marked body region**, instantiated N times via `tensor` / `Map` sizing at bind |
+
+- **Shape typing** (kind 1) is the "define the shape of the process that fits in"
+  requirement: the slot's `_slot` *is* an interface, and `bind` rejects a filler
+  whose `interface()` does not conform (§4.4). bigraph-schema already has the
+  vocabulary — `Link._inputs/_outputs`, `Edge.interface()` (`edge.py:144`),
+  `Interface` (`schema.py:664`), and `link[<inputs>,<outputs>]` typing.
+- **Cardinality** (kind 3) is the "change number of processes / store trees"
+  requirement: a value slot that additionally *generates structure* (§4.5).
+
+**Rejected alternatives:** *pure `reify_schema`* can't substitute a whole subtree
+into a place-graph position (that's `Site`/`compose`); *pure `Site`/`compose`* is
+awkward for a scalar like `n_seeds` and gives no interface typing or generative
+expansion. So: **one `Template` type; three slot kinds; `bind` dispatches per
+kind.** The new code is the slot metadata + the binding driver; substitution,
+resolution, interface checking, and tensor-expansion all reuse existing ops.
+
+---
+
+## 4. The primitives
+
+### 4.1 `Slot` — a named, typed hole
+
+A `Slot(Site)` subclass (so it *is* a place-graph hole and every existing
+`Site`-aware traversal — `interfaces`, `compose`, `is_ground` — already sees it):
+
+```python
+@dataclass(kw_only=True)
+class Slot(Site):
+    _schema_keys = Site._schema_keys | frozenset({'_name', '_slot', '_kind', '_optional'})
+    _name: str = ''            # slot identifier, unique within a template
+    _kind: str = 'value'       # 'process' | 'value' | 'cardinality'
+    _slot: Node = field(default_factory=Node)   # the slot's TYPE CONSTRAINT:
+                               #  process     → an INTERFACE: link[_inputs,_outputs]
+                               #                (+ optional address protocol) that a
+                               #                filler's interface() must conform to
+                               #  value       → a value schema (float/string/map[...])
+                               #  cardinality → an int (optionally range[lo,hi])
+    _optional: bool = False    # if True, an unbound slot falls back to _default
+    _target: list = field(default_factory=list)  # cardinality only: path of the
+                               # body region whose multiplicity this count drives
+```
+
+- `_kind` selects the binding mechanism (the §3 table). It is derivable from
+  `_slot` (an interface ⇒ `process`; an int with a `_target` ⇒ `cardinality`; else
+  `value`) — stored explicitly for clarity/validation.
+- A `process` slot's `_slot` is an **interface** (`link[in,out]` or `Interface`).
+  There is no runtime `composite` type; the hole stays a `Site` in the place graph,
+  and the interface constrains what may fill it (§4.4).
+- `render`/`access` round-trip and the `type[...]`/`{default}` grammar come for
+  free from `Node`/`Site`.
+
+### 4.2 `Template` — a schema with named slots + a body
+
+A template is a schema **document** (an ordinary bigraph) that contains `Slot`s in
+its place graph, plus a small header declaring the slots by name:
+
+```python
+@dataclass(kw_only=True)
+class Template(Node):
+    _schema_keys = Node._schema_keys | frozenset({'_slots', '_body'})
+    _slots: dict = field(default_factory=dict)   # name -> Slot (the declared holes)
+    _body: Node = field(default_factory=Node)    # the composite schema referencing them
+```
+
+- `_slots` is derived from the body on registration (walk `_body`, collect `Slot`s
+  by `_name`) — declaring it explicitly is an optimization/validation aid, not a
+  second source of truth. A single-composite study template is `len(_slots)==1`;
+  a comparison template (model-under-test vs. reference) is `len(_slots)==2`.
+- A `Template` is registered like any type (`core.register_type('template', Template)`
+  in `BASE_TYPES`), and downstream templates register via the `register_types`
+  discovery hook — so `study`, `investigation`, and concrete templates all become
+  bigraph-schema types (the umbrella's "bigraph-schema as the registry").
+
+### 4.3 `bind` — fill the slots → ground composite document
+
+The one genuinely new operation, a thin driver over existing machinery:
+
+```python
+def bind_template(core, template, bindings: dict) -> (schema, state):
+    """bindings: {slot_name: filler}. Returns a ground (Site-free) composite doc.
+    Order: cardinality slots FIRST (they expand structure, possibly creating new
+    process/value slots), then process slots, then value slots.
+      cardinality → expand the _target region to N instances (§4.5)
+      process     → check interface conformance (§4.4), then assembly.compose
+                    the filler subtree into the Slot's path + wire ports
+      value       → core.access filler → core.resolve into the Slot's path
+      missing     → _default if _optional else raise
+    Post: assembly.is_ground(result) (modulo optional process slots).
+    """
+```
+
+- **Process path:** `assert conforms(core, slot._slot, filler)` (§4.4), then
+  `assembly.compose` (via `_set_at_path`, `assembly.py:185`) places the filler root
+  at the slot's position and wires matching port names.
+- **Value path:** `core.access` the filler → `core.resolve` into the slot position
+  (the field-binding `reify_schema` uses, `handle_parameters.py:276`).
+- **Cardinality path:** §4.5, runs first so downstream slots see the expanded body.
+- Finish with `core.fill(result, {})` to realize defaults; assert `is_ground`.
+- Registered as a core method (`core.register_method('bind', …)`) → `core.bind(...)`.
+
+### 4.4 Interface conformance (shape of the process that fits)
+
+`conforms(core, required_interface, filler)`: the filler's interface —
+`filler.interface()` for an `Edge`/composite (`edge.py:144`), or the collected
+`_inputs`/`_outputs` of a subtree — must **satisfy** the slot's required interface:
+
+- every required input/output port is present with a **compatible type**
+  (`core.check` / `core.resolve` succeeds — structural subtyping, not equality, so
+  a filler may over-provide);
+- if the slot pins an address protocol, the filler's `address` matches.
+
+This is what lets a slot say "a process shaped `{glucose: float, biomass: map[float]}
+→ {growth_rate: float}`" and accept any registered process of that shape. Reuses
+existing type-compatibility (`core.check`, `core.resolve`) — no new type algebra.
+
+### 4.5 Generative cardinality (number of processes / store trees)
+
+A `cardinality` slot carries an int `n` and a `_target` path into the body marking
+a **repeatable region** (a subtree — a process, or a store subtree). On bind, the
+region is **instantiated `n` times** with indexed names:
+
+- **Homogeneous, keyed by name → `Map`.** The natural encoding of "N processes in a
+  store" is a `map[<region-schema>]` whose keys are the N instance ids; expansion
+  sets the map's contents to `{f'{name}_{i}': region for i in range(n)}`. This is
+  ordinary state, no new type.
+- **Positional / parallel → `tensor`.** When the copies are structurally parallel
+  (side-by-side subtrees, not a keyed store), `assembly.tensor` (`assembly.py:263`)
+  composes `n` disjoint copies.
+- **Numeric fan-out → `array` `_shape`.** A cardinality slot may instead set an
+  `Array`'s `_shape` (e.g. an `[n_replicas]` axis), reusing `array[...]` sizing
+  (`handle_parameters.py:89`).
+
+Expansion happens **before** process/value binding so a per-instance `process` or
+`value` slot inside the region is materialized `n` times and can be bound
+per-instance (or bound once and broadcast). Cardinality is the one kind that
+*generates* structure; keep its expansion a pure function of `(region, n)` so
+binding stays deterministic and re-runnable.
+
+---
+
+## 5. Key contracts (must be nailed)
+
+1. **Template document.** A registered schema with ≥1 `Slot`. Round-trips through
+   `render`/`access`. Serializable to `*.template.{yaml,json}` (the on-disk form
+   the workbench authors).
+2. **Slot type constraint (per kind).** `process` → an interface the filler's
+   `interface()` must **conform** to (§4.4); `value` → a value schema satisfying
+   `core.check(_slot, value)`; `cardinality` → an int (in `range` if given) with a
+   valid `_target` region path. `bind` validates each filler against its slot's
+   constraint and raises with a clear message on mismatch (shape mismatch, mistyped
+   value, out-of-range count).
+3. **Interface conformance is structural subtyping.** A filler may over-provide
+   ports/state; it must not under-provide any required port, and each shared port's
+   type must `resolve`. No exact-match requirement — this is what makes slots
+   reusable across processes of the same shape.
+4. **Generative expansion is a pure function of `(region, n)`.** Deterministic and
+   re-runnable; the same `n` always yields the same indexed structure. Cardinality
+   binding commits before process/value binding.
+5. **Binding result = ground composite.** `bind` returns `(schema, state)` with
+   **no remaining required Slots** (`is_ground` modulo optional slots) — exactly
+   what process-bigraph's `Composite` consumes (the Layer-2 handoff).
+4. **`CompositeSpec.parameters` subsumption.** A `CompositeSpec` with flat
+   `${name}` params is the **all-scalar-slots, single-body** special case of a
+   template. Layer 2 (process-bigraph) decides whether `CompositeSpec` becomes a
+   thin adapter that lowers to a `Template`, or is refactored onto it — **this spec
+   guarantees the template is a superset** (structural slots are the added power),
+   so no `CompositeSpec` capability is lost.
+
+---
+
+## 6. Tests
+
+Extend `tests.py` (the repo's single suite) alongside the existing golden cases:
+
+- **Structural fill** — mirror `test_compose_fills_sites` (1578): a `Template` with
+  one `process` slot; `bind` a conforming registered subtree; assert `is_ground`
+  and that the filler's `Link` ports wired.
+- **Shape conformance** — a `process` slot with interface
+  `link[{glucose:float},{growth_rate:float}]`; bind a matching process (passes,
+  incl. an over-providing one) and a non-matching one (raises with a shape-mismatch
+  message).
+- **Cardinality / generative** — a template with `n_replicas: cardinality` over a
+  `_target` region; `bind n=3` yields three indexed instances (as a `map` and, in a
+  second case, via `tensor`); `bind n=1` yields one; assert determinism (same `n` →
+  identical structure).
+- **Multi-slot** — a 2-slot comparison template (model-under-test + reference);
+  bind both; assert ground and both subtrees present at their paths.
+- **Value slot** — a `float`/`int` slot bound to a value; assert it lands and
+  `core.check` rejects a mistyped filler; assert an `_optional` slot falls back to
+  `_default`.
+- **Round-trip** — extend `test_render`/`do_round_trip` (431, 123) so a template
+  schema survives `access → render → access`.
+- **Registration/discovery** — a downstream stub module exposing `register_types`
+  that registers a template; assert `discover_packages` picks it up (extend
+  `tests/test_multi_package_dist_discovery.py`).
+- **Negative** — missing required binding raises; structural filler into a scalar
+  slot (and vice-versa) raises with a clear message.
+
+Golden references to stay consistent with: `test_uni_schema` (451) for the
+parameter grammar, `test_compose_*` (1578-1599) for substitution semantics.
+
+---
+
+## 7. Migration / compatibility
+
+- **Additive.** New `Slot`/`Template` types + a `bind` method; no existing type,
+  method, or test changes behavior. `BASE_TYPES` gains `slot`, `template`,
+  `composite` (alias).
+- No on-disk migration in *this* repo — `*.template.{yaml,json}` authoring and the
+  study/investigation migrator live in the workbench (Layer 4).
+- Minimum-version note for downstreams: process-bigraph's Study spec (Layer 2) must
+  pin the bigraph-schema version that introduces `bind`.
+
+---
+
+## 8. Risks & things to watch
+
+- **Two-mechanism seam.** Keep the structural/scalar split *inside* `bind`; callers
+  see one `bind(template, bindings)`. If a slot ever needs both (a subtree
+  *parameterized* by scalars), bind the scalars into the subtree first, then compose
+  — do not entangle the two paths.
+- **`Site` semantics.** `Slot` must remain a faithful `Site` so `interfaces`/
+  `compose`/`is_ground` keep working unmodified; add metadata, don't change hole
+  behavior. Guard with the existing Milner tests.
+- **`composite` is a marker, not a type.** Resist adding a real `composite` runtime
+  type here (that belongs to process-bigraph). Over-typing would fork the
+  "bigraph = the dict" invariant (`assembly.py:5`).
+- **Generative expansion order & naming.** Cardinality binds first and must produce
+  **stable, collision-free indexed names** (`{name}_{i}`); a per-instance slot
+  inside an expanded region multiplies the slot set, so `bind` must re-collect
+  slots after each cardinality expansion. Keep expansion a pure `(region, n)`
+  function — no dependence on bind order among cardinality slots — or nested
+  cardinalities (a store of N processes each with M sub-stores) become
+  non-deterministic. Cap `n` (guard against a param that explodes the document).
+- **Subsumption proof for `CompositeSpec`.** Layer 2 must show every current
+  `CompositeSpec.parameters` use lowers to scalar slots; a golden corpus from
+  process-bigraph should ride along when that layer lands.
+
+---
+
+## 9. Out of scope (YAGNI)
+
+- A runtime `composite`/`process`/`step` type (structural; belongs downstream).
+- Reaction-rule / rewrite semantics for templates (the `ReactionRule` engine
+  exists at `assembly.py:736` if ever needed — not now).
+- The study/investigation *documents* themselves and their migrator (Layers 2–4).
+- Any workbench UI (the ProcessCard viewer is the presentation side, separate).
+
+---
+
+## 10. Open decisions for review
+
+1. **`Slot` as a `Site` subclass vs. a `Site` + external name-registry.** Spec
+   recommends the subclass (keeps all Milner traversals working); confirm.
+2. **Where `composite` registers.** As a `Site`-alias marker here (recommended), or
+   deferred until process-bigraph defines a real composite type and templates
+   reference *that*? Recommendation: marker here, so bigraph-schema stays the
+   keystone with no upstream dependency.
+3. **`bind` return shape.** A ground schema only, or `(schema, state)` (schema +
+   realized default state)? Recommendation: `(schema, state)` so Layer 2 gets a
+   runnable composite directly, matching `Core.default`/`realize` conventions.

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -1,432 +1,269 @@
-# bigraph-schema `template` / `slot` primitive — design spec
+# bigraph-schema: sites, `fill`, and groundness — the template primitive
 
-**Status:** Design (Layer 1 of the framework-unification stack)
+**Status:** Design (Layer 1 of the framework-unification stack) · revised after Fable architecture review
 **Date:** 2026-07-30
 **Repo:** bigraph-schema (keystone — every layer above depends on this)
 **Umbrella:** `vivarium-workbench/docs/superpowers/specs/2026-07-29-framework-unification-design.md` (PR #676)
-**Depends on:** nothing upstream. **Consumed by:** process-bigraph (Study/Investigation composites), vivarium-workbench (templates → study docs), v2ecoli.
+**Review:** `~/AI-Generated/2026-07-30-architecture-unification-review-fable.md`
+**Depends on:** nothing upstream. **Consumed by:** process-bigraph, vivarium-workbench, v2ecoli.
 
 ---
 
-## 1. Goal
+## 1. Goal — one operation, one law
 
-Add a first-class **template**: a schema with **N named, typed slots** (holes).
-**Binding** the slots — supplying a filler per slot — produces a **concrete
-(ground) composite document**. A template must do **three** things:
+> There is one object: a **bigraph** — a typed document whose place graph is dict
+> nesting, whose link graph is `Link` nodes with faces and wires, and whose holes
+> are sorted **sites**. There is one operation: **`fill`** — substitute fillers
+> into named open sites. There is one law: a document is runnable exactly when it
+> is **ground** (no open sites, `is_ground`).
 
-1. **Constrain the shape of what fits a slot.** A slot is not "any composite" — it
-   declares the **interface** (required inputs/outputs, and optionally an address
-   protocol) that a filler process/composite must conform to. This is *structural
-   typing over the bigraph*: only a process whose `interface()` matches may fill it.
-2. **Parameterize scalar config.** Ordinary value slots (`float`, `string`,
-   `map[...]`, …) — the generalization of `CompositeSpec.parameters`' flat `${name}`
-   substitution.
-3. **Parameterize structure (generative).** Some parameters change the *shape of
-   the generated document*, not just leaf values — e.g. the **number of process
-   instances** in a store, or the **number of store subtrees**. A cardinality slot
-   drives multiplicity of a marked body region, expanding it into N instances on
-   bind.
+A **template is not a type**; it is simply a document that is **not yet ground**.
+Filling its sites produces a ground document that process-bigraph's `Composite`
+runs. This replaces the earlier framing (a new `Template`/`Slot` type + a bespoke
+`bind`) — the machinery already exists (§2); we add one predicate-checked wrapper.
 
-Litmus test (the umbrella's "template study"): a template whose composite slot —
-constrained to processes with a given interface — binds a model-under-test into a
-standard analysis-flush sub-network, with a cardinality slot for `n_seeds` /
-`n_replicas`. Drop any conforming registered composite (`ecoli_baseline`,
-`viva_munk.biofilm`, `pbg_copasi.steady-state`) into the slot → a runnable study
-document, no code.
+Templates still do three jobs, all as *sorts on sites*, all filled by the same
+`fill`:
 
----
+1. **Shape-constrain a filler** — a site's sort is a **face** (`link[in, out]`); a
+   filler is admissible iff its outer face conforms (§4.4). "The shape of the
+   process that fits" is Milner's face-matching, made typed.
+2. **Value config** — a site whose sort is a value type (`float`/`string`/`map`).
+   Generalizes `CompositeSpec`'s `${name}` — each `${name}` *is* a site (Layer 2a).
+3. **Generative structure** — "number of processes / store subtrees" as a
+   **reaction** that replicates a marked region *before* filling (§4.5), reusing
+   the existing `ReactionRule`/`fire_rule`, not a new operator.
 
-## 2. What already exists (grounding — do not rebuild)
+Litmus test: a template whose model-site is face-constrained; drop any conforming
+registered composite (`ecoli_baseline`, `viva_munk.biofilm`,
+`pbg_copasi.steady-state`) into it → a runnable study document, no code.
 
-Verified against the current tree (`bigraph_schema/`):
-
-- **There is no `composite` / `process` / `step` type here.** The bigraph *is*
-  the schema dict (dict nesting = place graph; `Link` nodes = link graph). A
-  "composite document" is a nested-dict schema+state; **`Link`** (`schema.py:273`)
-  is the edge/process/step primitive (`_inputs`/`_outputs` port-type maps +
-  `inputs`/`outputs` wires). `Edge` (`edge.py:23`) is its Python side, declaring
-  ports via `inputs()`/`outputs()`.
-- **Typed holes already exist — the Milner `Site`.** `Site(Empty)`
-  (`schema.py:603`) is "a hole in the place graph — an open inner-face position."
-  `assembly.compose(outer, inner)` (`assembly.py:185`) **substitutes each `Site`
-  in `outer` with a root from `inner`** (`_set_at_path`) and wires matching port
-  names; `is_ground(schema)` (`assembly.py:163`) is True when **no Sites remain**.
-  `interfaces(schema)` (`assembly.py:59`) enumerates the open sites/names. This is
-  a *tested* "typed holes → fill → concrete document" pipeline
-  (`tests.py:test_compose_fills_sites`, 1578).
-- **Parameter machinery.** `align_parameters` (positional→named,
-  `handle_parameters.py:63`) then `reify_schema` (`core.access` each param +
-  `core.resolve` into the field, `handle_parameters.py:177`). Generic `Node`
-  binding zips a type's `_schema_keys` fields with positional params
-  (`handle_parameters.py:162`, `276`). Grammar supports `type[X,Y]`, named
-  `type[a:X|b:Y]`, and `type{default}` (`parse.py:35`).
-- **Type definition & registry.** A type is a `@dataclass` `Node` subclass whose
-  **`_schema_keys` frozenset declares its parameter fields** (`schema.py`, e.g.
-  `Map:227`), with `field(default_factory=...)` defaults; behavior is added via
-  plum `@dispatch` methods under `methods/` (`default`, `apply`, `realize`, …).
-  Register via `core.register_type(name, cls)` (`core.py:188`) or in `BASE_TYPES`
-  (`schema.py:690`).
-- **Fill / defaults.** `Core.fill(schema, state)` (`core.py:743`) = build defaults
-  (`default.py`) then layer state; `Core.realize` (`core.py:599`) decodes/fills;
-  `realize_link` (`realize.py:608`) instantiates edges and merges port schemas.
-- **Cross-package registration/discovery.** `discover_packages` (`discover.py:228`)
-  auto-scans every dist that depends on `bigraph-schema`; a downstream module
-  exposing `register_types(core) -> core` is invoked on import
-  (`discover.py:158`); `Node`/`Edge` subclasses are found by class scan.
-
-**Consequence:** ~80% of "template" is present. The genuinely new pieces are (a) a
-**named, type-constrained slot** (today's `Site` carries only a `_sort`, no name
-or fill-type constraint), and (b) a **multi-slot binding operation** that is a thin
-layer over `compose` + `reify`/`fill`.
+Vocabulary is the shared glossary (umbrella §1 / review §3.4): **site**, **sort**,
+**admits**, **formation**, **face**, **wires**, **fill**, **compose**, **ground**,
+**template**, **document**, **edge**, **reaction**. This doc says *site* not slot,
+*fill* not bind/reify/substitute.
 
 ---
 
-## 3. The core design decision
+## 2. What already exists (verified — do not rebuild)
 
-**Binding is composition.** A template is a bigraph with an **inner face** made of
-named, typed holes; filling a slot is **composing** the template with a filler
-process-bigraph, following bigraph-schema's existing Milner algebra
-(`assembly.compose`/`tensor`/`interfaces`/`is_ground`) — *not* a bespoke
-`bind_template` side-mechanism. Where the current `compose` is too coarse we
-**extend it in a standard-preserving way**, we do not fork it. Concretely:
+Verified against the tree; **four earlier claims were wrong and are corrected here.**
 
-- Milner `compose(a: I→J, b: J→K) = ab: I→K` (`assembly.compose`, `assembly.py:185`)
-  already substitutes `Site`s and requires the shared face `J` to match. **The
-  "shape of the process that fits a slot" is precisely that face** — a slot's
-  declared interface *is* its local inner face; a filler composes iff its **outer
-  face matches** (§4.4). Interface conformance is therefore a *law of composition*,
-  not an extra check bolted on.
-- The extensions this spec adds — all consistent with the algebra:
-  1. **Named / partial composition.** Today's `compose` fills *all* sites
-     positionally. Templates need to fill **one named slot at a time** (and leave
-     others open), with a per-slot face. `compose_at(template, slot_name, filler)`
-     is compose localized to a single named site; repeated application fills the
-     rest and reduces to ordinary `compose` when there is one anonymous site.
-  2. **Typed faces.** A slot's face carries a required interface
-     (`link[inputs, outputs]`); the face-match becomes a `core.check`/`resolve`
-     (structural subtyping) instead of name-only matching.
-  3. **Parallel replication.** Cardinality reuses `tensor` (the standard parallel
-     product, `assembly.py:263`) to place N copies — replication is composition,
-     not a new operator.
+- **Sites are already named, sorted holes.** `Site(Empty)` with `_sort`
+  (`schema.py:604,623`); `interfaces` / `is_ground` / `compose` / `tensor`
+  (`assembly.py:59,163,185,263`). A site's **name is its key in the place graph** —
+  `instantiate`/`Match` already address sites by dict key (below). So there is no
+  need for a `_slots` header or a `Slot` subclass.
+- **`fill` already exists as `instantiate`.** `assembly.instantiate(reactum,
+  bindings, instantiation)` (`assembly.py:1044`) performs **named-site
+  substitution**: sites addressed by key, multi-root fillers spliced as forests,
+  single trees nested, everything deep-copied; it is tested through `fire_rule`.
+  This is the substitution half of `fill`.
+- **`is_ground`** (`assembly.py:163`) is the runnable predicate — no open sites.
+- **Sorting is a *nesting* discipline, not a filling one (correction).**
+  `Sorting.formation(parent_sort, child_sort)` (`assembly.py:376,444`,
+  `validate_sorting`) asks whether a child sort may live *inside* a parent sort;
+  it is **never consulted at a site**, and after `_set_at_path` the site's `_sort`
+  is gone. So admissibility needs a **separate** relation (`admits`, §4.4), not
+  `formation`.
+- **`Core.bind` already exists** (`core.py:732`): `bind(self, schema, state,
+  raw_key, target)` — a logical-key jump. Our operation must **not** shadow it;
+  register as **`core.fill_sites`** (a.k.a. `core.instantiate`).
+- **The `compose` link-branch is untested and probably wrong (correction).**
+  `test_compose_fills_sites` (`tests.py:1578`) composes `merge(2)` with two
+  `barren()` roots — **empty regions into empty holes**; no `Link`, port, or wire.
+  The link-composition branch (`assembly.py:245-256`) is unexercised and wires the
+  outer link to a path *inside the inner `Link` node* (`list(inner_link_path) +
+  [port_name]`) rather than at a store — dangling for any real document.
+  **Everything downstream sits on this branch → Task 0 (§6) must green it first.**
+- **Faces & edges.** `Link` (`schema.py:273`) has `address`, `config`,
+  `_inputs`/`_outputs` (faces = port *types*), `inputs`/`outputs` (wires).
+  `Edge.interface()` (`edge.py:144`) is the face's type map; a `Composite`'s
+  `bridge` is its outer face (Layer 2a states this once).
+- **Registration/discovery** — `core.register_type` (`core.py:188`) and the
+  `register_types(core)` discovery hook (`package/discover.py:158`). We need
+  **almost none** of this: `template` is a property (`not is_ground`), not a type.
 
-With that principle fixed, the per-kind dispatch is:
+---
 
-Two candidate mechanisms exist; the umbrella conflated them. This spec picks a
-**hybrid keyed on slot kind** — three kinds, matching the three goals in §1 — each
-expressed through the composition algebra above:
+## 3. The design — collapse five names to one
 
-| Slot kind | Filler | Type constraint | Mechanism |
-|---|---|---|---|
-| **process / composite** (structural, shape-typed) | a bigraph subtree / registered composite whose `interface()` conforms | an **interface**: required `_inputs`/`_outputs` (`link[in,out]`) + optional address protocol | **`Site` + `assembly.compose`** to substitute the subtree; **interface conformance check** before/at bind |
-| **value** (scalar config) | a value or leaf schema | a value type (`float`, `int`, `string`, `map[...]`, `enum[...]`) | **`reify_schema` / `core.resolve`** into the slot position |
-| **cardinality** (generative) | an `int` (or small value) that sets a **count** | `int` with optional `range[...]` | **generative expansion**: the count drives multiplicity of a **marked body region**, instantiated N times via `tensor` / `Map` sizing at bind |
+**`fill` is the only substitution primitive.** Everything else is a call to it:
 
-- **Shape typing** (kind 1) is the "define the shape of the process that fits in"
-  requirement: the slot's `_slot` *is* an interface, and `bind` rejects a filler
-  whose `interface()` does not conform (§4.4). bigraph-schema already has the
-  vocabulary — `Link._inputs/_outputs`, `Edge.interface()` (`edge.py:144`),
-  `Interface` (`schema.py:664`), and `link[<inputs>,<outputs>]` typing.
-- **Cardinality** (kind 3) is the "change number of processes / store trees"
-  requirement: a value slot that additionally *generates structure* (§4.5).
+```
+fill(core, body, bindings) -> body'        # instantiate (assembly.py:1044) + per-site admits check
+compose(outer, inner)  =  fill(outer, positional_bindings(outer, inner))   # Milner ∘, a 2-line adapter
+```
 
-**Rejected alternatives:** *pure `reify_schema`* can't substitute a whole subtree
-into a place-graph position (that's `Site`/`compose`); *pure `Site`/`compose`* is
-awkward for a scalar like `n_seeds` and gives no interface typing or generative
-expansion. So: **one `Template` type; three slot kinds; `bind` dispatches per
-kind.** The new code is the slot metadata + the binding driver; substitution,
-resolution, interface checking, and tensor-expansion all reuse existing ops.
+- **No `compose_at`.** "Fill one named site" is `fill(body, {name: filler})`;
+  filling all is the same call. There is no localized variant to keep in sync.
+- **No new `bind` name** (avoids the `Core.bind` collision) — register
+  `core.fill_sites`. A high-level `template + overrides` convenience may wrap it
+  (§4.3), but it is sugar, not a primitive.
+- **One site kind.** A `${name}` scalar and a model subtree differ *only in the
+  sort of the site they fill* — value vs. face. There are not three "slot kinds";
+  there is one sorted site and a per-sort `admits`.
+- **`compose` becomes a two-line adapter over `fill`** — the "no fork from the
+  standard" goal, achieved by *deletion*, not by rewriting `compose`.
+
+This is strictly less code than the previous draft and removes: `compose_at`, the
+`Slot` type, the `composite` slot-type, `Template._slots`, and three "slot kinds".
 
 ---
 
 ## 4. The primitives
 
-### 4.1 A slot *is* a sorted `Site` — not a new type
+### 4.1 A site is a sorted `Site`; its name is its key
 
-bigraph-schema already models a typed hole: `Site._sort` (`schema.py:623`, a
-Milner §6.2 sort label) + the sorting discipline in `assembly.py` (`Sorting`,
-`stratified_sorting`, `validate_sorting`, `formation(parent_sort, child_sort)`).
-**A slot is a `Site` whose `_sort` names the constraint on its filler** — we do
-**not** subclass `Site`. Every existing traversal (`interfaces`/`compose`/
-`is_ground`/`validate_sorting`) already handles it.
+No new type, no subclass. A typed hole is a `Site` whose `_sort` constrains its
+filler; its identity is its **key in the place graph** (how `instantiate` and
+`Match.bindings` already address sites). `optional`/`default` live **on the site**
+(`Site(_sort=…, _default=…)` — `Site` inherits `Empty`; a default is *state*, not
+header ceremony). Walking `_body` recovers all sites by key — there is no header.
 
-The constraint per kind is carried by the sort:
+### 4.2 A template is a non-ground document
 
-- **process slot** — `_sort` names a sort whose **formation is structural
-  interface conformance**: a filler is admissible iff its outer face
-  (`interface()` / collected `_inputs`,`_outputs`) conforms (§4.4). Sorts may be
-  registered by name (`'model'`) or given inline as an interface literal that
-  auto-registers an anonymous sort; either way the *mechanism* is the existing
-  `Sorting.formation` — we supply a formation that calls `core.check`/`resolve`
-  instead of nominal label-equality.
-- **value slot** — `_sort` is a value type (`float`/`string`/`map[...]`);
-  admissibility is `core.check(sort, value)`.
-- **cardinality** — *not a site.* Replication is a region-level annotation in the
-  Template header (§4.2), expanded via `tensor`; it is not a hole in the place
-  graph, so it does not live on `Site`.
+`template` is **not** a registered type and adds **nothing** to `BASE_TYPES`. It is
+the *property* `not is_ground(document)`. A study is a ground document; an
+investigation is a document with one site per dependent study (filled at runtime by
+gate edges — umbrella §4). This is the most Milner-faithful and least-code form.
 
-This keeps `Site` pure Milner (a sorted hole) and puts every ergonomic
-concern — the slot's **name**, **optionality**, and **cardinality** — in the
-Template header, where they belong.
-
-*(Subclassing `Slot(Site)` remains a fallback if we later want the name/optional
-flags physically on the hole; the recommendation is to avoid it — a slot is a
-sorted site, nothing more.)*
-
-### 4.2 `Template` — a schema with named slots + a body
-
-A template is a schema **document** (an ordinary bigraph) whose place graph
-contains sorted `Site`s, plus a small **header** that names them and declares the
-non-hole metadata (Milner sites are positional/anonymous — the header is where
-concrete names + optionality + cardinality live):
+### 4.3 `fill` (primitive) and the template convenience
 
 ```python
-@dataclass(kw_only=True)
-class Template(Node):
-    _schema_keys = Node._schema_keys | frozenset({'_slots', '_body'})
-    _body: Node = field(default_factory=Node)    # the composite schema, with sorted Sites
-    _slots: dict = field(default_factory=dict)   # slot_name -> {
-                                                 #   'path': [...],          # the Site's position
-                                                 #   'sort': <sort or interface literal>,
-                                                 #   'optional': bool,
-                                                 #   'cardinality': {'target':[...], 'range':[lo,hi]}?  }
+def fill_sites(core, body, bindings):        # core.fill_sites / core.instantiate
+    """Substitute fillers into named open sites (assembly.instantiate), checking
+    admits(core, site, filler) per site BEFORE substitution. Returns body'."""
+
+def build(core, template, overrides) -> (schema, state):   # convenience, NOT a primitive
+    """fill_sites(template_body, overrides) → core.fill(defaults) → assert is_ground
+    (modulo optional sites). Returns a runnable (schema, state)."""
 ```
 
-- `_slots` maps a **name → the Site's path** (+ its sort/optionality, and a
-  `cardinality` entry when the name drives a replicated region rather than fills a
-  hole). Names/paths are how `bind` addresses a specific slot; the sort is the
-  admissibility constraint validated by the `Sorting`.
-- `_slots` is recoverable from `_body` (walk it, collect sorted `Site`s by path);
-  the header is the authoritative *naming* layer + the home for cardinality (which
-  has no Site to attach to). Single-composite study template = one process slot;
-  comparison template (model-under-test vs. reference) = two.
-- A `Template` registers like any type (`core.register_type('template', Template)`
-  in `BASE_TYPES`); downstream templates register via the `register_types`
-  discovery hook — so `study`, `investigation`, and concrete templates all become
-  bigraph-schema types (the umbrella's "bigraph-schema as the registry").
+- `build` returns **`(schema, state)`** — a directly runnable composite for Layer 2,
+  matching `Core.default`/`realize`.
+- A partially-filled template is **still a template** (a document with a smaller
+  set of open sites) → templates fill into templates; filling is incremental.
 
-### 4.3 `compose_at` (the primitive) and `bind` (the sugar)
-
-The one genuinely new **primitive** is *named, typed, partial* composition — an
-extension of `assembly.compose`. `bind` is convenience sugar that folds a whole
-`{slot: filler}` map through it.
+### 4.4 `admits` — the filling discipline (≠ `formation`)
 
 ```python
-def compose_at(core, template, slot_name, filler):
-    """Compose one named slot. Extension of assembly.compose localized to a site.
-    Precondition: outer_face(filler) matches inner_face(template @ slot_name)  (§4.4)
-      process slot     → substitute filler subtree at the slot's path (compose)
-                         + wire the faces (existing port-name wiring, assembly.py:185)
-      value  slot      → core.access filler → core.resolve into the slot position
-      cardinality slot → tensor N copies of the _target region (§4.5)
-    Returns a template with that slot closed (others still open).
-    """
-
-def bind(core, template, bindings: dict) -> (schema, state):
-    """Fold compose_at over bindings → a ground (site-free) composite document.
-    Order: cardinality FIRST (replication grows the slot set), then process, then
-    value; re-collect slots after each cardinality step. Missing binding → _default
-    if _optional else raise. Then core.fill(result, {}); assert is_ground (modulo
-    optional slots). Registered as core methods → core.compose_at / core.bind."""
+def admits(core, site, filler) -> bool:
+    """Is `filler` admissible for this sorted site? Checked BEFORE substitution,
+    while the site (and its _sort) still exists. Default: face-conformance —
+    filler's outer face (Edge.interface() / collected _inputs,_outputs) satisfies
+    the site's face via core.resolve (structural subtyping: over-provide OK,
+    under-provide not). A value-sorted site defaults to core.check(sort, value)."""
 ```
 
-- When a template has a single anonymous site and the filler matches the whole
-  face, `compose_at` **is** `assembly.compose` — the extension degrades to the
-  existing operation (no divergence from the standard).
-- `compose_at` reuses the existing substitution (`_set_at_path`) and port-name
-  wiring; the *only* additions are (a) selecting one **named** site and (b) the
-  **typed** face-match (§4.4).
-- Because each step is a composition, a partially-bound template is **still a valid
-  template** (a bigraph with a smaller inner face) — templates compose with
-  templates, and binding can be incremental / streamed.
+`admits` (filling) and `formation` (nesting) are **two relations that share an
+arity**; do not conflate them. `validate_sorting` continues to police nesting
+*after* substitution. Register `admits` per sort (`core.register_sort(name, fn)`);
+a face literal auto-registers an anonymous sort whose `admits` is conformance.
+"Shape of the process that fits" = the site's face; a non-conforming filler is a
+**fill error** (equivalently a sorting violation), reported by name.
 
-### 4.4 Interface conformance = face matching (the composition law)
+### 4.5 Cardinality — a reaction, not a slot (kept, simplified)
 
-In Milner composition `a: I→J` ∘ `b: J→K` is defined **iff** the shared face `J`
-matches. A slot's declared interface *is* the template's local **inner face** at
-that site; the filler's **outer face** is `filler.interface()` (`edge.py:144`) or
-the collected `_inputs`/`_outputs` of the filler subtree. `compose_at` is defined
-iff:
+"Number of processes / store subtrees" is generative, so it is **not** a site fill
+— it is a **`ReactionRule`** applied *before* filling:
 
-- every port in the slot's face is present in the filler's outer face with a
-  **compatible type** — `core.check` / `core.resolve` succeeds (structural
-  subtyping: the filler may over-provide, never under-provide);
-- if the slot pins an address protocol, the filler's `address` matches.
+- The template marks a repeatable region; a count `n` fires a rule whose **redex**
+  is the marked region and **reactum** is *n* keyed copies, via the existing
+  `fire_rule` (`assembly.py:1142`). Determinism and collision-free naming come from
+  the existing `_remap_keys`/`_gensym_edge` — not restated as prose rules.
+- **One mechanism only** — `Map` with generated keys (the natural "N processes in a
+  store"); drop the earlier `tensor`/`array._shape` alternatives.
+- Runs before `fill_sites` so a per-instance site inside the region is materialized
+  `n` times, then filled per-instance (or filled once and broadcast).
 
-So "a process shaped `{glucose: float, biomass: map[float]} → {growth_rate: float}`"
-is a *face*, and any registered process whose outer face conforms composes into it.
-
-Mechanically this is the **existing sorting discipline** (`assembly.Sorting` /
-`validate_sorting`, `assembly.py:401-491`) with a `formation` that decides
-admissibility by **structural face-conformance** (`core.check`/`resolve`) rather
-than nominal label-equality. We add no new type algebra — only a formation callback
-that compares faces (not just port *names*). A non-conforming filler is a
-**composition error** (equivalently, a sorting violation), reported as such.
-
-### 4.5 Generative cardinality (number of processes / store trees)
-
-A `cardinality` slot carries an int `n` and a `_target` path into the body marking
-a **repeatable region** (a subtree — a process, or a store subtree). On bind, the
-region is **instantiated `n` times** with indexed names:
-
-- **Homogeneous, keyed by name → `Map`.** The natural encoding of "N processes in a
-  store" is a `map[<region-schema>]` whose keys are the N instance ids; expansion
-  sets the map's contents to `{f'{name}_{i}': region for i in range(n)}`. This is
-  ordinary state, no new type.
-- **Positional / parallel → `tensor`.** When the copies are structurally parallel
-  (side-by-side subtrees, not a keyed store), `assembly.tensor` (`assembly.py:263`)
-  composes `n` disjoint copies.
-- **Numeric fan-out → `array` `_shape`.** A cardinality slot may instead set an
-  `Array`'s `_shape` (e.g. an `[n_replicas]` axis), reusing `array[...]` sizing
-  (`handle_parameters.py:89`).
-
-Expansion happens **before** process/value binding so a per-instance `process` or
-`value` slot inside the region is materialized `n` times and can be bound
-per-instance (or bound once and broadcast). Cardinality is the one kind that
-*generates* structure; keep its expansion a pure function of `(region, n)` so
-binding stays deterministic and re-runnable.
+*(This keeps the user's explicit requirement — configurable process/store counts —
+while removing the seven ad-hoc rules the earlier draft invented.)*
 
 ---
 
-## 5. Key contracts (must be nailed)
+## 5. Contracts
 
-1. **Template document.** A registered schema with ≥1 `Slot`. Round-trips through
-   `render`/`access`. Serializable to `*.template.{yaml,json}` (the on-disk form
-   the workbench authors).
-2. **Slot type constraint (per kind).** `process` → an interface the filler's
-   `interface()` must **conform** to (§4.4); `value` → a value schema satisfying
-   `core.check(_slot, value)`; `cardinality` → an int (in `range` if given) with a
-   valid `_target` region path. `bind` validates each filler against its slot's
-   constraint and raises with a clear message on mismatch (shape mismatch, mistyped
-   value, out-of-range count).
-3. **Interface conformance is structural subtyping.** A filler may over-provide
-   ports/state; it must not under-provide any required port, and each shared port's
-   type must `resolve`. No exact-match requirement — this is what makes slots
-   reusable across processes of the same shape.
-4. **Generative expansion is a pure function of `(region, n)`.** Deterministic and
-   re-runnable; the same `n` always yields the same indexed structure. Cardinality
-   binding commits before process/value binding.
-5. **Binding result = ground composite.** `bind` returns `(schema, state)` with
-   **no remaining required Slots** (`is_ground` modulo optional slots) — exactly
-   what process-bigraph's `Composite` consumes (the Layer-2 handoff).
-6. **Composition consistency.** `compose_at` obeys the algebra: (a) it degrades to
-   `assembly.compose` for a single anonymous, whole-face site; (b) binding two
-   independent named slots **commutes** (order-independent) — order only matters
-   when one binding is inside a region a *cardinality* slot replicates, which is
-   why cardinality binds first; (c) a partially-bound template is itself a valid
-   template with a reduced inner face. These must hold as tests so the primitive
-   stays a true extension of composition, not a fork.
-4. **`CompositeSpec.parameters` subsumption.** A `CompositeSpec` with flat
-   `${name}` params is the **all-scalar-slots, single-body** special case of a
-   template. Layer 2 (process-bigraph) decides whether `CompositeSpec` becomes a
-   thin adapter that lowers to a `Template`, or is refactored onto it — **this spec
-   guarantees the template is a superset** (structural slots are the added power),
-   so no `CompositeSpec` capability is lost.
+1. **`fill` is a monoid action on documents.** Filling **independent** sites
+   commutes (order-independent); a partially filled document is still a document.
+   This law lets binding be incremental, lets gating fill sites at runtime, and lets
+   the viewer re-fill one site without rebuilding the world. Ordering matters only
+   when a cardinality reaction must expand a region before its inner sites exist.
+2. **`admits` gates every fill.** No substitution occurs unless the filler is
+   admissible for the site's sort (face-conformance / value-check). A mismatch is a
+   fill error naming the site.
+3. **Ground = runnable.** `build` returns `(schema, state)` with no open required
+   sites (`is_ground` modulo optional). Layer 2a enforces this at `Composite.__init__`.
+4. **`compose` is `fill` with positional bindings** — degrades exactly to today's
+   `assembly.compose` for anonymous whole-region sites; no divergence from Milner.
+5. **Template subsumption.** Every `CompositeSpec` lowers to a template such that
+   `build(to_template(spec), overrides) == to_document(spec, overrides)` for all
+   existing specs (Layer 2a golden corpus).
 
 ---
 
 ## 6. Tests
 
-Extend `tests.py` (the repo's single suite) alongside the existing golden cases:
-
-- **Structural fill** — mirror `test_compose_fills_sites` (1578): a `Template` with
-  one `process` slot; `bind` a conforming registered subtree; assert `is_ground`
-  and that the filler's `Link` ports wired.
-- **Shape conformance** — a `process` slot with interface
-  `link[{glucose:float},{growth_rate:float}]`; bind a matching process (passes,
-  incl. an over-providing one) and a non-matching one (raises with a shape-mismatch
-  message).
-- **Cardinality / generative** — a template with `n_replicas: cardinality` over a
-  `_target` region; `bind n=3` yields three indexed instances (as a `map` and, in a
-  second case, via `tensor`); `bind n=1` yields one; assert determinism (same `n` →
-  identical structure).
-- **Multi-slot** — a 2-slot comparison template (model-under-test + reference);
-  bind both; assert ground and both subtrees present at their paths.
-- **Value slot** — a `float`/`int` slot bound to a value; assert it lands and
-  `core.check` rejects a mistyped filler; assert an `_optional` slot falls back to
-  `_default`.
-- **Round-trip** — extend `test_render`/`do_round_trip` (431, 123) so a template
-  schema survives `access → render → access`.
-- **Registration/discovery** — a downstream stub module exposing `register_types`
-  that registers a template; assert `discover_packages` picks it up (extend
-  `tests/test_multi_package_dist_discovery.py`).
-- **Negative** — missing required binding raises; structural filler into a scalar
-  slot (and vice-versa) raises with a clear message.
-
-Golden references to stay consistent with: `test_uni_schema` (451) for the
-parameter grammar, `test_compose_*` (1578-1599) for substitution semantics.
+- **Task 0 (blocking).** Compose a **`Link`-bearing subtree into a site inside a
+  wired document** and assert the resulting **wires resolve** (ports read from
+  stores, not from link nodes). This exercises the untested link-composition branch
+  (`assembly.py:245-256`); fix its wire target if broken. **Nothing else is built
+  until this is green.**
+- **`fill` + `admits`.** Fill a face-sorted site with a conforming process (incl.
+  an over-providing one) → passes; a non-conforming one → fill error naming the
+  site. Fill a value site; reject a mistyped value; `_default` fallback for an
+  optional site.
+- **Composition law.** Filling two independent sites commutes; a partially filled
+  document is still fillable; `compose` degrades to `assembly.compose` on empties.
+- **Cardinality.** A marked region + `n=3` yields three keyed instances
+  deterministically (same `n` → identical); `n=1` yields one.
+- **Round-trip.** A non-ground document survives `access → render → access`.
+- **Naming/collision.** Assert `core.fill_sites` does not shadow `Core.bind`.
 
 ---
 
 ## 7. Migration / compatibility
 
-- **Additive.** New `Slot`/`Template` types + a `bind` method; no existing type,
-  method, or test changes behavior. `BASE_TYPES` gains `slot`, `template`,
-  `composite` (alias).
-- No on-disk migration in *this* repo — `*.template.{yaml,json}` authoring and the
-  study/investigation migrator live in the workbench (Layer 4).
-- Minimum-version note for downstreams: process-bigraph's Study spec (Layer 2) must
-  pin the bigraph-schema version that introduces `bind`.
+Additive. New `core.fill_sites` + `admits`/`register_sort`; `compose` re-expressed
+over `fill` (signature preserved). `BASE_TYPES` unchanged. No on-disk migration
+here (that is Layer 2a/4). Downstreams pin the bigraph-schema version that adds
+`fill_sites`.
 
 ---
 
-## 8. Risks & things to watch
+## 8. Risks
 
-- **Two-mechanism seam.** Keep the structural/scalar split *inside* `bind`; callers
-  see one `bind(template, bindings)`. If a slot ever needs both (a subtree
-  *parameterized* by scalars), bind the scalars into the subtree first, then compose
-  — do not entangle the two paths.
-- **`Site` semantics.** `Slot` must remain a faithful `Site` so `interfaces`/
-  `compose`/`is_ground` keep working unmodified; add metadata, don't change hole
-  behavior. Guard with the existing Milner tests.
-- **`composite` is a marker, not a type.** Resist adding a real `composite` runtime
-  type here (that belongs to process-bigraph). Over-typing would fork the
-  "bigraph = the dict" invariant (`assembly.py:5`).
-- **Generative expansion order & naming.** Cardinality binds first and must produce
-  **stable, collision-free indexed names** (`{name}_{i}`); a per-instance slot
-  inside an expanded region multiplies the slot set, so `bind` must re-collect
-  slots after each cardinality expansion. Keep expansion a pure `(region, n)`
-  function — no dependence on bind order among cardinality slots — or nested
-  cardinalities (a store of N processes each with M sub-stores) become
-  non-deterministic. Cap `n` (guard against a param that explodes the document).
-- **Subsumption proof for `CompositeSpec`.** Layer 2 must show every current
-  `CompositeSpec.parameters` use lowers to scalar slots; a golden corpus from
-  process-bigraph should ride along when that layer lands.
+- **The link-composition branch is load-bearing and unproven** — Task 0 is the gate
+  (§6). Do not build on it blind.
+- **`admits` vs `formation` confusion** — keep them two named relations; test that
+  `admits` fires *before* substitution and `validate_sorting` *after*.
+- **Cardinality determinism** — the reaction must produce stable keyed names; reuse
+  `_remap_keys`/`_gensym_edge`; cap `n`.
+- **Name hygiene** — `fill_sites`, not `bind` (collision); `site`, not `slot`.
 
 ---
 
 ## 9. Out of scope (YAGNI)
 
 - A runtime `composite`/`process`/`step` type (structural; belongs downstream).
-- Reaction-rule / rewrite semantics for templates (the `ReactionRule` engine
-  exists at `assembly.py:736` if ever needed — not now).
-- The study/investigation *documents* themselves and their migrator (Layers 2–4).
-- Any workbench UI (the ProcessCard viewer is the presentation side, separate).
+- The study/investigation documents + migrator (Layers 2–4).
+- Any workbench UI (the ProcessCard viewer is the presentation side).
+- General template rewrite semantics beyond the one cardinality reaction.
 
 ---
 
 ## 10. Decisions (resolved 2026-07-30)
 
-Milner grounding: in bigraph theory the holes are **sites** (numbered, untyped);
-composition plugs a filler's **roots into the context's sites** and is defined iff
-the shared **face** matches; constraining what may fill a hole is a **sorting**.
-bigraph-schema's `Site` is exactly Milner's site. Our `Slot` therefore = a
-**concrete (named) site under a sorting discipline (a typed face)** — a recognized
-extension, not a departure. This validates decisions 1 & 4 below.
+Milner grounding: holes are **sites** (numbered/keyed, sorted); composition plugs a
+filler's roots into sites, defined iff the shared **face** matches; constraining a
+hole is a **sorting**. All four decisions land as *deletions*:
 
-1. **A slot *is* a sorted `Site` — no subclass** ✅ — `Site._sort` + the existing
-   `Sorting`/`validate_sorting` discipline already model a typed hole. A slot is a
-   `Site` whose sort's `formation` is structural interface conformance. The slot's
-   **name, optionality, and cardinality** live in the **Template header** (Milner
-   sites are anonymous/positional), keeping `Site` pure. (Subclassing `Slot(Site)`
-   is a fallback only if we later want name/optional physically on the hole.)
-2. **`composite` stays a marker here; the composite concept is hardened in
-   process-bigraph** ✅ — bigraph-schema keeps no runtime `composite` type (no
-   upstream dep). The first-class `Composite` / `generate_composite` lives and is
-   hardened in **process-bigraph** (Layer 2), which references this template
-   machinery — including migrating `viva_superpowers`'s composite-generator into
-   process-bigraph.
-3. **`bind` returns `(schema, state)`** ✅ — a directly runnable composite for
-   Layer 2; matches `Core.default`/`realize`.
-4. **Extend `assembly.compose` in place** ✅ — re-express `compose` as `compose_at`
-   over the single anonymous site (one code path, old signature preserved); no
-   parallel wrapper that could drift from the standard.
+1. **A slot is a keyed, sorted `Site` — no subclass, no `Slot` type.** Name = key;
+   sort = filling constraint; `optional`/`default` on the site.
+2. **`composite` is not a slot type** — a "composite" filler is just an edge with a
+   (possibly empty) face; the real composite concept is hardened in process-bigraph.
+   `BASE_TYPES` gains nothing.
+3. **`build` returns `(schema, state)`** — runnable for Layer 2.
+4. **`fill` is the one primitive; `compose` is a two-line adapter over it; register
+   `core.fill_sites`** (never shadow `Core.bind`). `assembly.instantiate` already
+   implements the substitution.

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -205,6 +205,47 @@ face is the contract, the address is the hole.
   `Protocol` for `realize`. Address *injection* is address *resolution* applied to a
   filled address — the same fix enables both.
 
+### 4.7 The contract = the face (typed core) + semantics + amendments
+
+"The face is the contract" generalises: a **contract** is the full interface spec of
+an **edge *or* a site**, and the **face** (`_inputs`/`_outputs`) is its
+machine-checkable **typed core** — the part `admits` reads. This *unifies* the face
+with the existing `ProcessContract` / `Edge.describe_contract()`
+(`bigraph_schema/contract.py`), which already carries the documentary part (summary,
+math, per-port semantics, assumptions, references). They are not two objects: the
+face is the **typed projection** of one contract.
+
+- **Universal.** `describe_contract()` today answers only for edges; extend it to
+  **every edge and every site** — a **site's sort *is* a contract**. A template site
+  says "a process satisfying *this contract*" (typed face + documented meaning), not
+  merely "shaped like X". So the face-as-contract holds at exactly the granularity
+  you fill.
+- **`admits` = `face_conforms` + amendment predicates.** The face decides typed
+  admissibility; amendments may add predicate-bearing constraints.
+
+**Amendments** — an ordered, append-only, provenance-carrying refinement of a
+contract:
+
+```
+amendment = { op, target, detail, by, when, why }
+   op ∈  narrow    (tighten the face / add a port or constraint)
+         annotate  (add or refine a description / per-port semantics)
+```
+
+Decision (per review): **`narrow` + `annotate` only** — a contract may get *stricter*
+and *better-documented* as it flows down, never looser and never gain new ports
+(`extend` is out until a use case demands it). This keeps amendment **monotone**, so
+`admits` stays sound: a filler admissible for an amended (narrower) contract is
+admissible for the original. Amendments give you the *description of a contract* as a
+first-class, editable thing, and — because each carries `by/when/why` — the
+**provenance** of how an interface evolved through composition and filling.
+
+- `amend(contract, amendment)` is pure and append-only; a composite's contract is its
+  constituents' contracts, amended.
+- Lands downstream: Layer 2a exposes one `describe_contract` for composites; the
+  viewer's contract region renders it (face + description + amendments), and a site
+  renders its *required* contract.
+
 ## 5. Contracts
 
 1. **`fill` is a monoid action on documents.** Filling **independent** sites
@@ -241,6 +282,11 @@ face is the contract, the address is the hole.
   `admits` passes and the filled edge `realize`s to a runnable process; inject a
   non-conforming address → fill error naming the face mismatch. Assert the two
   flavors (address-hole vs. whole-edge site) both go through the same `fill`.
+- **Contract + amendments (§4.7).** `describe_contract` answers for a **site** (its
+  required contract) as well as an edge; `amend` is append-only; a `narrow` amendment
+  makes `admits` **stricter** (a filler rejected after narrowing was admissible
+  before — monotonicity); `annotate` changes docs without changing admissibility;
+  `extend` is refused.
 - **Composition law.** Filling two independent sites commutes; a partially filled
   document is still fillable; `compose` degrades to `assembly.compose` on empties.
 - **Cardinality.** A marked region + `n=3` yields three keyed instances

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -140,56 +140,67 @@ resolution, interface checking, and tensor-expansion all reuse existing ops.
 
 ## 4. The primitives
 
-### 4.1 `Slot` — a named, typed hole
+### 4.1 A slot *is* a sorted `Site` — not a new type
 
-A `Slot(Site)` subclass (so it *is* a place-graph hole and every existing
-`Site`-aware traversal — `interfaces`, `compose`, `is_ground` — already sees it):
+bigraph-schema already models a typed hole: `Site._sort` (`schema.py:623`, a
+Milner §6.2 sort label) + the sorting discipline in `assembly.py` (`Sorting`,
+`stratified_sorting`, `validate_sorting`, `formation(parent_sort, child_sort)`).
+**A slot is a `Site` whose `_sort` names the constraint on its filler** — we do
+**not** subclass `Site`. Every existing traversal (`interfaces`/`compose`/
+`is_ground`/`validate_sorting`) already handles it.
 
-```python
-@dataclass(kw_only=True)
-class Slot(Site):
-    _schema_keys = Site._schema_keys | frozenset({'_name', '_slot', '_kind', '_optional'})
-    _name: str = ''            # slot identifier, unique within a template
-    _kind: str = 'value'       # 'process' | 'value' | 'cardinality'
-    _slot: Node = field(default_factory=Node)   # the slot's TYPE CONSTRAINT:
-                               #  process     → an INTERFACE: link[_inputs,_outputs]
-                               #                (+ optional address protocol) that a
-                               #                filler's interface() must conform to
-                               #  value       → a value schema (float/string/map[...])
-                               #  cardinality → an int (optionally range[lo,hi])
-    _optional: bool = False    # if True, an unbound slot falls back to _default
-    _target: list = field(default_factory=list)  # cardinality only: path of the
-                               # body region whose multiplicity this count drives
-```
+The constraint per kind is carried by the sort:
 
-- `_kind` selects the binding mechanism (the §3 table). It is derivable from
-  `_slot` (an interface ⇒ `process`; an int with a `_target` ⇒ `cardinality`; else
-  `value`) — stored explicitly for clarity/validation.
-- A `process` slot's `_slot` is an **interface** (`link[in,out]` or `Interface`).
-  There is no runtime `composite` type; the hole stays a `Site` in the place graph,
-  and the interface constrains what may fill it (§4.4).
-- `render`/`access` round-trip and the `type[...]`/`{default}` grammar come for
-  free from `Node`/`Site`.
+- **process slot** — `_sort` names a sort whose **formation is structural
+  interface conformance**: a filler is admissible iff its outer face
+  (`interface()` / collected `_inputs`,`_outputs`) conforms (§4.4). Sorts may be
+  registered by name (`'model'`) or given inline as an interface literal that
+  auto-registers an anonymous sort; either way the *mechanism* is the existing
+  `Sorting.formation` — we supply a formation that calls `core.check`/`resolve`
+  instead of nominal label-equality.
+- **value slot** — `_sort` is a value type (`float`/`string`/`map[...]`);
+  admissibility is `core.check(sort, value)`.
+- **cardinality** — *not a site.* Replication is a region-level annotation in the
+  Template header (§4.2), expanded via `tensor`; it is not a hole in the place
+  graph, so it does not live on `Site`.
+
+This keeps `Site` pure Milner (a sorted hole) and puts every ergonomic
+concern — the slot's **name**, **optionality**, and **cardinality** — in the
+Template header, where they belong.
+
+*(Subclassing `Slot(Site)` remains a fallback if we later want the name/optional
+flags physically on the hole; the recommendation is to avoid it — a slot is a
+sorted site, nothing more.)*
 
 ### 4.2 `Template` — a schema with named slots + a body
 
-A template is a schema **document** (an ordinary bigraph) that contains `Slot`s in
-its place graph, plus a small header declaring the slots by name:
+A template is a schema **document** (an ordinary bigraph) whose place graph
+contains sorted `Site`s, plus a small **header** that names them and declares the
+non-hole metadata (Milner sites are positional/anonymous — the header is where
+concrete names + optionality + cardinality live):
 
 ```python
 @dataclass(kw_only=True)
 class Template(Node):
     _schema_keys = Node._schema_keys | frozenset({'_slots', '_body'})
-    _slots: dict = field(default_factory=dict)   # name -> Slot (the declared holes)
-    _body: Node = field(default_factory=Node)    # the composite schema referencing them
+    _body: Node = field(default_factory=Node)    # the composite schema, with sorted Sites
+    _slots: dict = field(default_factory=dict)   # slot_name -> {
+                                                 #   'path': [...],          # the Site's position
+                                                 #   'sort': <sort or interface literal>,
+                                                 #   'optional': bool,
+                                                 #   'cardinality': {'target':[...], 'range':[lo,hi]}?  }
 ```
 
-- `_slots` is derived from the body on registration (walk `_body`, collect `Slot`s
-  by `_name`) — declaring it explicitly is an optimization/validation aid, not a
-  second source of truth. A single-composite study template is `len(_slots)==1`;
-  a comparison template (model-under-test vs. reference) is `len(_slots)==2`.
-- A `Template` is registered like any type (`core.register_type('template', Template)`
-  in `BASE_TYPES`), and downstream templates register via the `register_types`
+- `_slots` maps a **name → the Site's path** (+ its sort/optionality, and a
+  `cardinality` entry when the name drives a replicated region rather than fills a
+  hole). Names/paths are how `bind` addresses a specific slot; the sort is the
+  admissibility constraint validated by the `Sorting`.
+- `_slots` is recoverable from `_body` (walk it, collect sorted `Site`s by path);
+  the header is the authoritative *naming* layer + the home for cardinality (which
+  has no Site to attach to). Single-composite study template = one process slot;
+  comparison template (model-under-test vs. reference) = two.
+- A `Template` registers like any type (`core.register_type('template', Template)`
+  in `BASE_TYPES`); downstream templates register via the `register_types`
   discovery hook — so `study`, `investigation`, and concrete templates all become
   bigraph-schema types (the umbrella's "bigraph-schema as the registry").
 
@@ -243,10 +254,13 @@ iff:
 
 So "a process shaped `{glucose: float, biomass: map[float]} → {growth_rate: float}`"
 is a *face*, and any registered process whose outer face conforms composes into it.
-This is the standard's own well-definedness condition made **typed** — we reuse
-`core.check`/`core.resolve`, adding no new type algebra, only the requirement that
-the faces (not just port *names*) align. A non-conforming filler is a
-**composition error**, reported as such.
+
+Mechanically this is the **existing sorting discipline** (`assembly.Sorting` /
+`validate_sorting`, `assembly.py:401-491`) with a `formation` that decides
+admissibility by **structural face-conformance** (`core.check`/`resolve`) rather
+than nominal label-equality. We add no new type algebra — only a formation callback
+that compares faces (not just port *names*). A non-conforming filler is a
+**composition error** (equivalently, a sorting violation), reported as such.
 
 ### 4.5 Generative cardinality (number of processes / store trees)
 
@@ -390,20 +404,29 @@ parameter grammar, `test_compose_*` (1578-1599) for substitution semantics.
 
 ---
 
-## 10. Open decisions for review
+## 10. Decisions (resolved 2026-07-30)
 
-1. **`Slot` as a `Site` subclass vs. a `Site` + external name-registry.** Spec
-   recommends the subclass (keeps all Milner traversals working); confirm.
-2. **Where `composite` registers.** As a `Site`-alias marker here (recommended), or
-   deferred until process-bigraph defines a real composite type and templates
-   reference *that*? Recommendation: marker here, so bigraph-schema stays the
-   keystone with no upstream dependency.
-3. **`bind` return shape.** A ground schema only, or `(schema, state)` (schema +
-   realized default state)? Recommendation: `(schema, state)` so Layer 2 gets a
-   runnable composite directly, matching `Core.default`/`realize` conventions.
-4. **Extend `assembly.compose` in place vs. a new `compose_at`.** The named/typed/
-   partial composition is a strict generalization of today's `compose`.
-   Recommendation: add `compose_at` alongside `compose` and re-express `compose` as
-   `compose_at` over the (single, anonymous) site — one code path, the old
-   signature preserved — rather than a parallel wrapper that could drift from the
-   standard. Confirm this refactor is acceptable in the `assembly` module.
+Milner grounding: in bigraph theory the holes are **sites** (numbered, untyped);
+composition plugs a filler's **roots into the context's sites** and is defined iff
+the shared **face** matches; constraining what may fill a hole is a **sorting**.
+bigraph-schema's `Site` is exactly Milner's site. Our `Slot` therefore = a
+**concrete (named) site under a sorting discipline (a typed face)** — a recognized
+extension, not a departure. This validates decisions 1 & 4 below.
+
+1. **A slot *is* a sorted `Site` — no subclass** ✅ — `Site._sort` + the existing
+   `Sorting`/`validate_sorting` discipline already model a typed hole. A slot is a
+   `Site` whose sort's `formation` is structural interface conformance. The slot's
+   **name, optionality, and cardinality** live in the **Template header** (Milner
+   sites are anonymous/positional), keeping `Site` pure. (Subclassing `Slot(Site)`
+   is a fallback only if we later want name/optional physically on the hole.)
+2. **`composite` stays a marker here; the composite concept is hardened in
+   process-bigraph** ✅ — bigraph-schema keeps no runtime `composite` type (no
+   upstream dep). The first-class `Composite` / `generate_composite` lives and is
+   hardened in **process-bigraph** (Layer 2), which references this template
+   machinery — including migrating `viva_superpowers`'s composite-generator into
+   process-bigraph.
+3. **`bind` returns `(schema, state)`** ✅ — a directly runnable composite for
+   Layer 2; matches `Core.default`/`realize`.
+4. **Extend `assembly.compose` in place** ✅ — re-express `compose` as `compose_at`
+   over the single anonymous site (one code path, old signature preserved); no
+   parallel wrapper that could drift from the standard.

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -83,9 +83,37 @@ layer over `compose` + `reify`/`fill`.
 
 ## 3. The core design decision
 
+**Binding is composition.** A template is a bigraph with an **inner face** made of
+named, typed holes; filling a slot is **composing** the template with a filler
+process-bigraph, following bigraph-schema's existing Milner algebra
+(`assembly.compose`/`tensor`/`interfaces`/`is_ground`) — *not* a bespoke
+`bind_template` side-mechanism. Where the current `compose` is too coarse we
+**extend it in a standard-preserving way**, we do not fork it. Concretely:
+
+- Milner `compose(a: I→J, b: J→K) = ab: I→K` (`assembly.compose`, `assembly.py:185`)
+  already substitutes `Site`s and requires the shared face `J` to match. **The
+  "shape of the process that fits a slot" is precisely that face** — a slot's
+  declared interface *is* its local inner face; a filler composes iff its **outer
+  face matches** (§4.4). Interface conformance is therefore a *law of composition*,
+  not an extra check bolted on.
+- The extensions this spec adds — all consistent with the algebra:
+  1. **Named / partial composition.** Today's `compose` fills *all* sites
+     positionally. Templates need to fill **one named slot at a time** (and leave
+     others open), with a per-slot face. `compose_at(template, slot_name, filler)`
+     is compose localized to a single named site; repeated application fills the
+     rest and reduces to ordinary `compose` when there is one anonymous site.
+  2. **Typed faces.** A slot's face carries a required interface
+     (`link[inputs, outputs]`); the face-match becomes a `core.check`/`resolve`
+     (structural subtyping) instead of name-only matching.
+  3. **Parallel replication.** Cardinality reuses `tensor` (the standard parallel
+     product, `assembly.py:263`) to place N copies — replication is composition,
+     not a new operator.
+
+With that principle fixed, the per-kind dispatch is:
+
 Two candidate mechanisms exist; the umbrella conflated them. This spec picks a
 **hybrid keyed on slot kind** — three kinds, matching the three goals in §1 — each
-reusing existing machinery:
+expressed through the composition algebra above:
 
 | Slot kind | Filler | Type constraint | Mechanism |
 |---|---|---|---|
@@ -165,47 +193,60 @@ class Template(Node):
   discovery hook — so `study`, `investigation`, and concrete templates all become
   bigraph-schema types (the umbrella's "bigraph-schema as the registry").
 
-### 4.3 `bind` — fill the slots → ground composite document
+### 4.3 `compose_at` (the primitive) and `bind` (the sugar)
 
-The one genuinely new operation, a thin driver over existing machinery:
+The one genuinely new **primitive** is *named, typed, partial* composition — an
+extension of `assembly.compose`. `bind` is convenience sugar that folds a whole
+`{slot: filler}` map through it.
 
 ```python
-def bind_template(core, template, bindings: dict) -> (schema, state):
-    """bindings: {slot_name: filler}. Returns a ground (Site-free) composite doc.
-    Order: cardinality slots FIRST (they expand structure, possibly creating new
-    process/value slots), then process slots, then value slots.
-      cardinality → expand the _target region to N instances (§4.5)
-      process     → check interface conformance (§4.4), then assembly.compose
-                    the filler subtree into the Slot's path + wire ports
-      value       → core.access filler → core.resolve into the Slot's path
-      missing     → _default if _optional else raise
-    Post: assembly.is_ground(result) (modulo optional process slots).
+def compose_at(core, template, slot_name, filler):
+    """Compose one named slot. Extension of assembly.compose localized to a site.
+    Precondition: outer_face(filler) matches inner_face(template @ slot_name)  (§4.4)
+      process slot     → substitute filler subtree at the slot's path (compose)
+                         + wire the faces (existing port-name wiring, assembly.py:185)
+      value  slot      → core.access filler → core.resolve into the slot position
+      cardinality slot → tensor N copies of the _target region (§4.5)
+    Returns a template with that slot closed (others still open).
     """
+
+def bind(core, template, bindings: dict) -> (schema, state):
+    """Fold compose_at over bindings → a ground (site-free) composite document.
+    Order: cardinality FIRST (replication grows the slot set), then process, then
+    value; re-collect slots after each cardinality step. Missing binding → _default
+    if _optional else raise. Then core.fill(result, {}); assert is_ground (modulo
+    optional slots). Registered as core methods → core.compose_at / core.bind."""
 ```
 
-- **Process path:** `assert conforms(core, slot._slot, filler)` (§4.4), then
-  `assembly.compose` (via `_set_at_path`, `assembly.py:185`) places the filler root
-  at the slot's position and wires matching port names.
-- **Value path:** `core.access` the filler → `core.resolve` into the slot position
-  (the field-binding `reify_schema` uses, `handle_parameters.py:276`).
-- **Cardinality path:** §4.5, runs first so downstream slots see the expanded body.
-- Finish with `core.fill(result, {})` to realize defaults; assert `is_ground`.
-- Registered as a core method (`core.register_method('bind', …)`) → `core.bind(...)`.
+- When a template has a single anonymous site and the filler matches the whole
+  face, `compose_at` **is** `assembly.compose` — the extension degrades to the
+  existing operation (no divergence from the standard).
+- `compose_at` reuses the existing substitution (`_set_at_path`) and port-name
+  wiring; the *only* additions are (a) selecting one **named** site and (b) the
+  **typed** face-match (§4.4).
+- Because each step is a composition, a partially-bound template is **still a valid
+  template** (a bigraph with a smaller inner face) — templates compose with
+  templates, and binding can be incremental / streamed.
 
-### 4.4 Interface conformance (shape of the process that fits)
+### 4.4 Interface conformance = face matching (the composition law)
 
-`conforms(core, required_interface, filler)`: the filler's interface —
-`filler.interface()` for an `Edge`/composite (`edge.py:144`), or the collected
-`_inputs`/`_outputs` of a subtree — must **satisfy** the slot's required interface:
+In Milner composition `a: I→J` ∘ `b: J→K` is defined **iff** the shared face `J`
+matches. A slot's declared interface *is* the template's local **inner face** at
+that site; the filler's **outer face** is `filler.interface()` (`edge.py:144`) or
+the collected `_inputs`/`_outputs` of the filler subtree. `compose_at` is defined
+iff:
 
-- every required input/output port is present with a **compatible type**
-  (`core.check` / `core.resolve` succeeds — structural subtyping, not equality, so
-  a filler may over-provide);
+- every port in the slot's face is present in the filler's outer face with a
+  **compatible type** — `core.check` / `core.resolve` succeeds (structural
+  subtyping: the filler may over-provide, never under-provide);
 - if the slot pins an address protocol, the filler's `address` matches.
 
-This is what lets a slot say "a process shaped `{glucose: float, biomass: map[float]}
-→ {growth_rate: float}`" and accept any registered process of that shape. Reuses
-existing type-compatibility (`core.check`, `core.resolve`) — no new type algebra.
+So "a process shaped `{glucose: float, biomass: map[float]} → {growth_rate: float}`"
+is a *face*, and any registered process whose outer face conforms composes into it.
+This is the standard's own well-definedness condition made **typed** — we reuse
+`core.check`/`core.resolve`, adding no new type algebra, only the requirement that
+the faces (not just port *names*) align. A non-conforming filler is a
+**composition error**, reported as such.
 
 ### 4.5 Generative cardinality (number of processes / store trees)
 
@@ -253,6 +294,13 @@ binding stays deterministic and re-runnable.
 5. **Binding result = ground composite.** `bind` returns `(schema, state)` with
    **no remaining required Slots** (`is_ground` modulo optional slots) — exactly
    what process-bigraph's `Composite` consumes (the Layer-2 handoff).
+6. **Composition consistency.** `compose_at` obeys the algebra: (a) it degrades to
+   `assembly.compose` for a single anonymous, whole-face site; (b) binding two
+   independent named slots **commutes** (order-independent) — order only matters
+   when one binding is inside a region a *cardinality* slot replicates, which is
+   why cardinality binds first; (c) a partially-bound template is itself a valid
+   template with a reduced inner face. These must hold as tests so the primitive
+   stays a true extension of composition, not a fork.
 4. **`CompositeSpec.parameters` subsumption.** A `CompositeSpec` with flat
    `${name}` params is the **all-scalar-slots, single-body** special case of a
    template. Layer 2 (process-bigraph) decides whether `CompositeSpec` becomes a
@@ -353,3 +401,9 @@ parameter grammar, `test_compose_*` (1578-1599) for substitution semantics.
 3. **`bind` return shape.** A ground schema only, or `(schema, state)` (schema +
    realized default state)? Recommendation: `(schema, state)` so Layer 2 gets a
    runnable composite directly, matching `Core.default`/`realize` conventions.
+4. **Extend `assembly.compose` in place vs. a new `compose_at`.** The named/typed/
+   partial composition is a strict generalization of today's `compose`.
+   Recommendation: add `compose_at` alongside `compose` and re-express `compose` as
+   `compose_at` over the (single, anonymous) site — one code path, the old
+   signature preserved — rather than a parallel wrapper that could drift from the
+   standard. Confirm this refactor is acceptable in the `assembly` module.

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -182,6 +182,29 @@ while removing the seven ad-hoc rules the earlier draft invented.)*
 
 ---
 
+### 4.6 Address injection — an abstract process (interface without implementation)
+
+An edge has an `address` (its implementation/protocol), a `config`, a **face**
+(`_inputs`/`_outputs` — port types), and **wires**. A template may leave the
+**`address` as a site** while fixing the face (and config schema + wiring). That is
+**a process definition without an implementation** — an *abstract process*: the
+face is the contract, the address is the hole.
+
+- **Fill = inject the address.** The filler is an `address` naming a registered
+  process; `admits` requires that process's `interface()` to **conform to the
+  site's face** (§4.4). Same `fill`, same `admits` — no new machinery; the site's
+  filler is an address string rather than a subtree.
+- Two flavors, both one operation: **(a) address-hole, else-fixed** — only the
+  *implementation* varies (pure implementation-swap); **(b) whole-edge site** —
+  inject a full process/composite.
+- **Payoff:** flavor (a) is the solver/model-swap pattern — one solver face, inject
+  `copasi` / `tellurium` / `simbio` — i.e. a cross-simulator comparison expressed as
+  *one template with an address site*. In component-model terms it is a required
+  interface satisfied by plugging in a conforming implementation.
+- Depends on address resolution (§11 Task A): an injected address must resolve to a
+  `Protocol` for `realize`. Address *injection* is address *resolution* applied to a
+  filled address — the same fix enables both.
+
 ## 5. Contracts
 
 1. **`fill` is a monoid action on documents.** Filling **independent** sites
@@ -213,6 +236,11 @@ while removing the seven ad-hoc rules the earlier draft invented.)*
   an over-providing one) → passes; a non-conforming one → fill error naming the
   site. Fill a value site; reject a mistyped value; `_default` fallback for an
   optional site.
+- **Address injection (abstract process, §4.6).** A template edge with a fixed face
+  and an **`address` site**: inject a conforming registered process's address →
+  `admits` passes and the filled edge `realize`s to a runnable process; inject a
+  non-conforming address → fill error naming the face mismatch. Assert the two
+  flavors (address-hole vs. whole-edge site) both go through the same `fill`.
 - **Composition law.** Filling two independent sites commutes; a partially filled
   document is still fillable; `compose` degrades to `assembly.compose` on empties.
 - **Cardinality.** A marked region + `n=3` yields three keyed instances

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -359,24 +359,36 @@ ports to one shared store, rebased through the site; `compose` raises naming the
 when a join isn't expressible. Also fixed: `render` dropped a site's `_sort` (leaked a
 Python object into the JSON document) — face-sorted templates now round-trip.
 
-### Open decision (resolve at Layer 2a's first task)
+### Decision 5 — RESOLVED (place semantics): keep the wrapper / site-position form ✅
 
-5. **`fill_sites` place semantics: aim at forest-splice (Milner-correct).**
-   `instantiate` forest-splices a multi-root filler **at the parent** (roots are
-   *regions*); `compose`'s `_set_at_path` keeps the site's key as a **wrapper node**.
-   `fill_sites` currently follows `compose` (conservative — no behavior change). The
-   **decision:** move toward the Milner forest-splice, validated with **evidence** —
-   Layer 2a's first task fills a *real composite* into a site and picks the semantics
-   against what `Composite` actually consumes (updating `compose`'s tests if changed).
-   Until then `fill_sites` follows `compose`.
+`fill_sites` keeps `compose`'s semantics — a filler goes **at the site's position**,
+not forest-spliced at the parent — now documented and tested (not incidental).
+`compose` is unchanged. Evidence from a live `Composite` against a real registered
+process: forest-splicing a nested composite **drops the site's key** and **collides**
+the filler's inner keys with the template's own (silently losing one), and violates
+composition arity (one root → one site). `instantiate`'s forest-splice is correct for
+reaction **matching** (a redex site captures sibling keys) — a different operation.
 
-### Deferred (next Fable pass)
+### Status (all green: 1113 tests, PR #175)
 
-- **Cardinality** as a single `ReactionRule` (§4.5) — redex = marked region, reactum =
-  N keyed copies, fired via `fire_rule` before `fill_sites`.
-- **`build(core, template, overrides)`** convenience (§4.3) → `(schema, state)`.
+- **Address resolution — done.** Root cause: a link's `address` was compiled by the
+  *type parser* (`core.access`), never becoming a `Protocol`, so `default`/`realize`/
+  `render` walked it as a schema. Fix: one `schema.normalize_address` that `access`
+  and `realize` share; `render(Protocol/Link)` corrected (also fixed a second
+  pre-existing bug — an address-less link couldn't realize). Plus: `collect_face`
+  now resolves a filler's face from `core.link_registry` (a real process declares
+  address + config, not ports) — `admits` no longer rejects every genuine filler.
+- **Done earlier:** cardinality reaction (§4.5), `build()` (§4.3).
 
-### Flagged, orthogonal (separate fix)
+### In flight (queued Fable batch)
 
+- **Address-injection** explicit tests (§4.6).
+- **Contract = face + amendments** (§4.7) — `describe_contract` to sites, `amend`
+  (`narrow`/`annotate`), `admits` via the contract.
+
+### Flagged, carried to Layer 2a (process-bigraph)
+
+- `Composite.run()` **hangs on `IncreaseProcess`** even at `interval:1.0` — a real
+  process-bigraph bug, unrelated to this layer.
 - `is_bound`/`find_unbound_links` (`assembly.py:570`) read wires absolute-from-root,
   contradicting `port_merges`' relative-to-parent — untested; left alone.

--- a/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-slot-primitive-design.md
@@ -267,3 +267,42 @@ hole is a **sorting**. All four decisions land as *deletions*:
 4. **`fill` is the one primitive; `compose` is a two-line adapter over it; register
    `core.fill_sites`** (never shadow `Core.bind`). `assembly.instantiate` already
    implements the substitution.
+
+---
+
+## 11. Implementation status (2026-07-30 · PR #175)
+
+Built by Fable; **1086 tests pass, 0 failures** (baseline 1067). Shipped:
+`assembly.fill_sites` (the primitive), `admits`/`admits_why`/`face_conforms`/
+`collect_face`/`collect_sites`, `compose` re-expressed over one shared substitution,
+`core.fill_sites`/`register_sort`/`admits`. All deletions held (no `compose_at`,
+`Slot`/`Template`, `_slots`; `BASE_TYPES` unchanged).
+
+**Task 0 found the foundation was broken (3 bugs, now fixed + tested).** The
+untested `compose` link-branch (a) never rebased the wire → realization crashed,
+(b) pointed inside a `Link` node, (c) wired only one end. Fixed: a join wires **both**
+ports to one shared store, rebased through the site; `compose` raises naming the port
+when a join isn't expressible. Also fixed: `render` dropped a site's `_sort` (leaked a
+Python object into the JSON document) — face-sorted templates now round-trip.
+
+### Open decision (resolve at Layer 2a's first task)
+
+5. **`fill_sites` place semantics: aim at forest-splice (Milner-correct).**
+   `instantiate` forest-splices a multi-root filler **at the parent** (roots are
+   *regions*); `compose`'s `_set_at_path` keeps the site's key as a **wrapper node**.
+   `fill_sites` currently follows `compose` (conservative — no behavior change). The
+   **decision:** move toward the Milner forest-splice, validated with **evidence** —
+   Layer 2a's first task fills a *real composite* into a site and picks the semantics
+   against what `Composite` actually consumes (updating `compose`'s tests if changed).
+   Until then `fill_sites` follows `compose`.
+
+### Deferred (next Fable pass)
+
+- **Cardinality** as a single `ReactionRule` (§4.5) — redex = marked region, reactum =
+  N keyed copies, fired via `fire_rule` before `fill_sites`.
+- **`build(core, template, overrides)`** convenience (§4.3) → `(schema, state)`.
+
+### Flagged, orthogonal (separate fix)
+
+- `is_bound`/`find_unbound_links` (`assembly.py:570`) read wires absolute-from-root,
+  contradicting `port_merges`' relative-to-parent — untested; left alone.


### PR DESCRIPTION
**Layer 1** of the framework-unification stack (umbrella: vivarium-workbench PR #676). Design spec only — no code.

A **template** = a schema with N named, typed **slots**; **binding** the slots produces a **ground composite document**. Grounded in machinery bigraph-schema already has (`Site`/`assembly.compose`/`is_ground`, `align_parameters`/`reify_schema`, `Link`/`Edge.interface()`, `register_type` + the `discover` hook) — there is *no* runtime `composite` type here (a composite is structural).

**Three slot kinds** (per the goal that templates do three things):
1. **process** (structural, shape-typed) — a `Site` whose **interface** constrains what process/composite may fill it; substitute via `compose`, conform via `core.check`.
2. **value** (scalar config) — `reify_schema`/`core.resolve`; generalizes `CompositeSpec.parameters`' flat `${name}`.
3. **cardinality** (generative) — an int that drives **multiplicity of a marked body region** (number of processes / store trees), expanded via `Map` / `tensor` / `array` sizing.

Additive, no behavior changes. Ends with **§10 open decisions for review** (Slot-as-Site subclass; `composite` marker-vs-deferred; `bind` returning `(schema, state)`).

> Draft for review — not for merge until the open decisions are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)