### PR TITLE
feat(assembly): fill — one substitution primitive + fix the broken compose link-branch

### DIFF
--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -102,6 +102,12 @@ def interfaces(schema):
                     if port not in wired_out:
                         outer_names[port] = path
 
+            # An edge may leave its *implementation* open: a site in
+            # ``address`` (or ``config``) is an abstract process — the face is
+            # fixed and only what satisfies it is missing.
+            walk(node.address, path + ('address',))
+            walk(node.config, path + ('config',))
+
         elif isinstance(node, (Wires, Path)):
             # Link-graph wiring structure — not place-graph children.
             pass
@@ -584,6 +590,19 @@ def validate_sorting(schema, sorting, path=()):
 #       job.
 
 
+def is_address(value):
+    """True when ``value`` spells an edge address rather than a subtree.
+
+    An address is a string (``'local:copasi'``, ``'copasi'``) or the canonical
+    ``{'protocol', 'data'}`` dict — the two forms ``normalize_address``
+    accepts.
+    """
+    if isinstance(value, str):
+        return bool(value)
+    return (isinstance(value, dict)
+            and 'protocol' in value and 'data' in value)
+
+
 def _face_from_address(core, address, config):
     """Resolve an edge's ports from the class its address names.
 
@@ -639,6 +658,14 @@ def collect_face(core, node):
     if callable(interface):
         face = interface() or {}
         return dict(face.get('inputs') or {}), dict(face.get('outputs') or {})
+
+    # A bare address is a filler in its own right — the abstract-process case,
+    # where only the implementation is being injected. Its face is the face of
+    # the process it names.
+    if is_address(node):
+        resolved = _face_from_address(core, node, None)
+        if resolved is not None:
+            return resolved
 
     def declared(get, address, config):
         found_in = get('_inputs')
@@ -788,10 +815,18 @@ def _as_schema(core, site, filler):
     state. An unsorted site has no sort to carry the value, so the raw
     filler stands (the pure-Milner case).
     """
+    sort = getattr(site, '_sort', '')
+
+    # Injecting an implementation: a face-sorted site filled with an *address*
+    # compiles to a Protocol, the same shape ``access`` gives a declared
+    # address — so the filled edge realizes exactly like a written one.
+    if core is not None and isinstance(sort, Link) and is_address(filler):
+        from bigraph_schema.methods.handle_parameters import access_address
+        return access_address(core, filler)
+
     if isinstance(filler, (Node, dict)):
         return filler
 
-    sort = getattr(site, '_sort', '')
     if not sort or core is None:
         return filler
 

--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -27,7 +27,7 @@ formal definitions.
 import copy
 import random
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Optional, Dict, List as TypingList, Tuple as TypingTuple
 
 from bigraph_schema.schema import (
@@ -698,22 +698,53 @@ def admits(core, site, filler):
 
 
 def collect_sites(body):
-    """Map each open site's **name** to its path.
+    """Map each open site's **address** to ``(path, site)``.
 
-    A site's name is its key in the place graph — the same convention
-    ``instantiate`` and ``Match.bindings`` already use. Raises when one
-    name is ambiguous across two paths, since bindings address sites by
-    name.
+    A site is addressed by its key in the place graph — the convention
+    ``instantiate`` and ``Match.bindings`` already use — and *always* also
+    by its full ``/``-joined path. The path form is what distinguishes
+    sites that replication (:func:`replicate`) has given the same key in
+    different copies of a region. A bare key shared by more than one site
+    is simply not registered, so using it is an error that can name the
+    alternatives rather than silently filling the wrong hole.
     """
+    places = list(interfaces(body)[0]._places)
+
+    shared = {}
+    for path, _site in places:
+        shared.setdefault(path[-1] if path else '', []).append(path)
+
     sites = {}
-    for path, site in interfaces(body)[0]._places:
+    for path, site in places:
+        sites['/'.join(path)] = (path, site)
         name = path[-1] if path else ''
-        if name in sites:
-            raise ValueError(
-                f'fill: site name {name!r} is ambiguous — it appears at '
-                f'{sites[name][0]} and at {path}')
-        sites[name] = (path, site)
+        if len(shared[name]) == 1:
+            sites[name] = (path, site)
+
     return sites
+
+
+def _as_schema(core, site, filler):
+    """Shape a filler for substitution into a *schema* tree.
+
+    A structural filler is already a subtree and goes in as-is. A **value**
+    filler is state, not schema — so it lands as the site's own sort
+    carrying that value as its default. Filling a document therefore keeps
+    it a document, and ``core.fill`` later materializes the value into
+    state. An unsorted site has no sort to carry the value, so the raw
+    filler stands (the pure-Milner case).
+    """
+    if isinstance(filler, (Node, dict)):
+        return filler
+
+    sort = getattr(site, '_sort', '')
+    if not sort or core is None:
+        return filler
+
+    schema = core.access(sort)
+    if isinstance(schema, Node):
+        return replace(schema, _default=filler)
+    return filler
 
 
 def _fill_at_paths(core, body, filling):
@@ -732,7 +763,8 @@ def _fill_at_paths(core, body, filling):
             raise ValueError(
                 f'fill: filler rejected for site {label!r} at {path}: '
                 f'{reason}')
-        _set_at_path(result, path, copy.deepcopy(filler))
+        _set_at_path(
+            result, path, copy.deepcopy(_as_schema(core, site, filler)))
 
     return result
 
@@ -752,21 +784,193 @@ def fill_sites(core, body, bindings):
 
     unknown = set(bindings) - set(sites)
     if unknown:
-        raise ValueError(
-            f'fill: no such site(s): {sorted(unknown)} '
-            f'(open sites: {sorted(sites)})')
+        hints = []
+        for name in sorted(unknown):
+            alternatives = sorted(
+                address for address, (path, _site) in sites.items()
+                if '/' in address and path and path[-1] == name)
+            if alternatives:
+                hints.append(
+                    f'{name!r} names more than one site — address it by '
+                    f'path, one of {alternatives}')
+        detail = '; '.join(hints) if hints else (
+            f'open sites: {sorted(sites)}')
+        raise ValueError(f'fill: no such site(s): {sorted(unknown)} — {detail}')
+
+    # A site carries up to two addresses (bare key and path); resolve every
+    # binding down to the path it designates so both spellings agree.
+    bound = {}
+    for address, filler in bindings.items():
+        path, _site = sites[address]
+        if path in bound and bound[path][1] is not filler:
+            raise ValueError(
+                f'fill: the site at {path} is bound twice, as '
+                f'{bound[path][0]!r} and as {address!r}')
+        bound[path] = (address, filler)
 
     filling = {}
-    for name, (path, site) in sites.items():
-        if name in bindings:
-            filler = bindings[name]
+    for address, (path, site) in sites.items():
+        if path in filling:
+            continue
+        if path in bound:
+            label, filler = bound[path]
         elif getattr(site, '_default', None) is not None:
-            filler = site._default
+            label, filler = address, site._default
         else:
             continue                    # left open, still a site
-        filling[path] = (name, site, filler)
+        filling[path] = (label, site, filler)
 
     return _fill_at_paths(core, body, filling)
+
+
+# ── Cardinality: replication is a reaction, not a kind of site ──────
+# "How many processes / store subtrees" changes the *shape* of the
+# document, so it is not a hole to be filled — it is a rewrite. Milner
+# already has the right tool: a parametric reaction rule whose reactum
+# mentions the redex's parameter more than once shares that parameter
+# across every occurrence (§8.1, p. 83). Replication is exactly that
+# rule, so this adds no operator — only the rule and a driver.
+
+REPLICATE = 'replicate'
+"""The control marking a repeatable region. A node carrying
+``_control: 'replicate'`` is replicated by :func:`replicate` into keyed
+copies; the copies do not carry the mark, so replication is idempotent
+and the rewrite reaches quiescence on its own."""
+
+COUNT_KEY = '_count'
+"""Optional default count on a marked region, overridable at build time."""
+
+MAX_REPLICAS = 1024
+"""Guard against a count that explodes the document."""
+
+
+def collect_regions(body):
+    """Map each marked region's name (its key) to its path."""
+    regions = {}
+
+    def walk(node, path):
+        if not isinstance(node, dict):
+            return
+        if node.get('_control') == REPLICATE:
+            name = path[-1] if path else ''
+            if name in regions:
+                raise ValueError(
+                    f'replicate: region name {name!r} is ambiguous — it '
+                    f'appears at {regions[name]} and at {path}')
+            regions[name] = path
+            return                      # regions do not nest through a mark
+        for key, child in node.items():
+            if isinstance(key, str) and not key.startswith('_'):
+                walk(child, path + (key,))
+
+    walk(body, ())
+    return regions
+
+
+def replicate_rule(name, count):
+    """The cardinality rule: one marked region in, ``count`` copies out.
+
+    The redex is the marked region with a single site capturing its
+    contents; the reactum is ``count`` keyed copies whose sites all
+    instantiate from that *same* redex site — Milner's shared parameter.
+    The copies drop the mark, so the rule cannot fire on its own output.
+    """
+    return ReactionRule(
+        redex={name: {'_control': REPLICATE, 'contents': Site()}},
+        reactum={
+            f'{name}_{index}': {'contents': Site()}
+            for index in range(count)},
+        instantiation={
+            f'{name}_{index}': 'contents' for index in range(count)},
+        label=f'replicate {name} x{count}')
+
+
+def replicate(body, counts=None):
+    """Expand every marked region into keyed copies, before filling.
+
+    ``counts`` maps a region's name to its count, overriding the region's
+    own ``_count``; a region with neither stays single. Regions are
+    expanded one at a time, re-walking after each firing because
+    expansion changes paths — and because a copied region may itself
+    contain a marked sub-region.
+
+    Deterministic: the copy keys are ``<name>_<i>`` for ``i`` in order, and
+    the region to expand is chosen in walk order, so the same input and
+    the same counts always yield the identical document.
+    """
+    counts = counts or {}
+    body = copy.deepcopy(body)
+
+    for _ in range(MAX_REPLICAS):
+        regions = collect_regions(body)
+        if not regions:
+            return body
+
+        name, path = next(iter(regions.items()))
+        region = _get_at_path(body, path)
+        count = counts.get(name, region.get(COUNT_KEY, 1))
+
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f'replicate: count for region {name!r} must be a '
+                f'non-negative int, got {count!r}')
+        if count > MAX_REPLICAS:
+            raise ValueError(
+                f'replicate: count {count} for region {name!r} exceeds '
+                f'MAX_REPLICAS ({MAX_REPLICAS})')
+
+        rule = replicate_rule(name, count)
+
+        # The redex matches any node bearing the mark, so select the match
+        # that is *this* region: same parent, and the pattern key assigned
+        # to this region's key.
+        parent = tuple(path[:-1])
+        index = next(
+            (position for position, match in enumerate(
+                find_matches(body, rule.redex))
+             if tuple(match.path) == parent and match.key_map.get(name) == name),
+            None)
+        if index is None:
+            raise ValueError(
+                f'replicate: marked region {name!r} at {path} did not match '
+                f'its own rule')
+
+        body, _match = fire_rule(body, rule, match_index=index)
+
+    raise ValueError(
+        f'replicate: more than {MAX_REPLICAS} regions expanded — a marked '
+        f'region is probably regenerating the mark')
+
+
+# ── build — the template convenience (sugar, not a primitive) ───────
+
+
+def build(core, template, overrides=None):
+    """Replicate, fill, default, and check groundness. Returns
+    ``(schema, state)`` — directly runnable by process-bigraph.
+
+    ``overrides`` carries region counts *and* site fillers in one map;
+    a key naming a marked region is a count, anything else is a filler.
+    Not a primitive: every step is an existing operation.
+    """
+    overrides = overrides or {}
+
+    regions = collect_regions(template)
+    counts = {name: overrides[name] for name in regions if name in overrides}
+    body = replicate(template, counts)
+
+    bindings = {key: value for key, value in overrides.items()
+                if key not in counts}
+    schema = fill_sites(core, body, bindings)
+
+    open_sites = [path for path, _site in interfaces(schema)[0]._places]
+    if open_sites:
+        raise ValueError(
+            'build: document is not ground — required site(s) left '
+            'unfilled: ' + ', '.join(
+                repr('/'.join(path)) for path in sorted(open_sites)))
+
+    return schema, core.fill(schema, {})
 
 
 # ── Binding / link locality ─────────────────────────────────────────

--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -32,7 +32,7 @@ from typing import Optional, Dict, List as TypingList, Tuple as TypingTuple
 
 from bigraph_schema.schema import (
     Node, Empty, Site, Interface, Link, Wires, Path, Place,
-    Map, List, Set, Tree, Tuple, Wrap, Union,
+    Map, List, Set, Tree, Tuple, Wrap, Union, Protocol, normalize_address,
     is_schema_field)
 
 
@@ -584,14 +584,53 @@ def validate_sorting(schema, sorting, path=()):
 #       job.
 
 
-def collect_face(node):
-    """Collect a filler's **outer face** — the ports it declares.
+def _face_from_address(core, address, config):
+    """Resolve an edge's ports from the class its address names.
+
+    A real process declaration carries an **address** and a config, not its
+    ports — the ports live on the registered class and are only known once
+    it is built. Without this, a site could only ever be filled by a
+    declaration that restated its own interface, which no registered
+    process does.
+
+    Returns ``None`` when the address names nothing this core knows, so the
+    caller can fall back to whatever was declared.
+    """
+    if core is None:
+        return None
+
+    if isinstance(address, Protocol):
+        address = address._default
+    canonical = normalize_address(address)
+    if not isinstance(canonical, dict):
+        return None
+
+    edge_class = getattr(core, 'link_registry', {}).get(canonical.get('data'))
+    if edge_class is None:
+        return None
+
+    if isinstance(config, Node):
+        config = config._default
+    if not isinstance(config, dict):
+        config = {}
+
+    try:
+        face = edge_class(config, core).interface() or {}
+    except Exception:
+        return None
+
+    return dict(face.get('inputs') or {}), dict(face.get('outputs') or {})
+
+
+def collect_face(core, node):
+    """Collect a filler's **outer face** — the ports it exposes.
 
     Returns an ``(inputs, outputs)`` pair of port-type maps. An ``Edge``
     instance reports its own via ``interface()`` (``edge.py``); a ``Link``
-    reports ``_inputs``/``_outputs``; a subtree reports the union of the
-    Links it contains. Declared ports are used regardless of wiring — a
-    filler exposes its interface whether or not it is internally wired.
+    reports ``_inputs``/``_outputs``, or — when it declares none — the ports
+    of the class its address names; a subtree reports the union of the Links
+    it contains. Declared ports are used regardless of wiring: a filler
+    exposes its interface whether or not it is internally wired.
     """
     inputs = {}
     outputs = {}
@@ -601,18 +640,33 @@ def collect_face(node):
         face = interface() or {}
         return dict(face.get('inputs') or {}), dict(face.get('outputs') or {})
 
+    def declared(get, address, config):
+        found_in = get('_inputs')
+        found_out = get('_outputs')
+        found_in = found_in if isinstance(found_in, dict) else {}
+        found_out = found_out if isinstance(found_out, dict) else {}
+        if not found_in and not found_out:
+            resolved = _face_from_address(core, address, config)
+            if resolved is not None:
+                return resolved
+        return found_in, found_out
+
     def walk(subnode):
         if isinstance(subnode, Link):
-            if isinstance(subnode._inputs, dict):
-                inputs.update(subnode._inputs)
-            if isinstance(subnode._outputs, dict):
-                outputs.update(subnode._outputs)
+            found_in, found_out = declared(
+                lambda key: getattr(subnode, key, None),
+                getattr(subnode, 'address', None),
+                getattr(subnode, 'config', None))
+            inputs.update(found_in)
+            outputs.update(found_out)
         elif isinstance(subnode, dict):
-            if subnode.get('_type') == 'link':
-                if isinstance(subnode.get('_inputs'), dict):
-                    inputs.update(subnode['_inputs'])
-                if isinstance(subnode.get('_outputs'), dict):
-                    outputs.update(subnode['_outputs'])
+            if subnode.get('_type') in ('link', 'process', 'step'):
+                found_in, found_out = declared(
+                    subnode.get,
+                    subnode.get('address'),
+                    subnode.get('config'))
+                inputs.update(found_in)
+                outputs.update(found_out)
                 return
             for key, child in subnode.items():
                 if isinstance(key, str) and not key.startswith('_'):
@@ -632,7 +686,7 @@ def face_conforms(core, face, filler):
 
     Returns ``(ok, reason)``.
     """
-    provided = dict(zip(('inputs', 'outputs'), collect_face(filler)))
+    provided = dict(zip(("inputs", "outputs"), collect_face(core, filler)))
 
     for direction, port_key in (('inputs', '_inputs'), ('outputs', '_outputs')):
         required = getattr(face, port_key, None)
@@ -754,6 +808,23 @@ def _fill_at_paths(core, body, filling):
     filler is checked with :func:`admits` *before* substitution — while the
     site still exists — and a rejection is a fill error naming the site.
     Paths not in ``filling`` are left open.
+
+    **Place semantics (settled).** A filler is substituted **at the site's
+    own position**; it is not forest-spliced into the site's parent, which
+    is what ``instantiate`` does when a *redex* site captures several
+    sibling keys during matching. Reaction-matching and composition are
+    different operations and this is where they differ:
+
+    - Milner composition plugs **one root into one site**, so a filler with
+      n roots fills n sites — ``compose`` already enforces that arity.
+      Splicing a multi-root filler into a single site would silently turn
+      one hole into n nodes.
+    - Splicing drops the site's key, so the filled region loses the name the
+      template gave it, and merges the filler's roots into the parent's
+      namespace where they can collide with the template's own stores.
+    - Empirically, ``process_bigraph.Composite`` reports a filled model site
+      at ``('study', 'model')`` — it expects the process node exactly where
+      the site was, with a nested composite's internals kept under it.
     """
     result = copy.deepcopy(body)
 

--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -703,6 +703,90 @@ def collect_face(core, node):
     return inputs, outputs
 
 
+def contract_of(core, node):
+    """The contract of an **edge or a site** — universal ``describe_contract``.
+
+    A site's sort *is* a contract: a template site says "something satisfying
+    *this* contract", not merely "shaped like X". So the same call answers for
+    the thing that fills a hole and for the hole itself, and at exactly the
+    granularity you fill.
+
+    - a **site** → the contract it *requires*: a sort naming a registered
+      contract resolves to that contract (amendments included); a face
+      literal yields a contract whose typed core is that face.
+    - an **edge instance** → its own ``describe_contract``.
+    - a **link schema** → its declared face, or the face of the class its
+      address names, merged with that class's documented contract.
+
+    Returns ``None`` when the node carries no interface at all.
+    """
+    from bigraph_schema.contract import ProcessContract, resolve_contract
+
+    if node is None:
+        return None
+
+    if isinstance(node, Site):
+        sort = getattr(node, '_sort', '')
+        if isinstance(sort, str) and sort:
+            registered = getattr(core, 'contract_registry', {}).get(sort)
+            if registered is not None:
+                return registered
+            sort = core.access(sort) if core is not None else sort
+        if isinstance(sort, Link):
+            return contract_of(core, sort)
+        return None
+
+    if callable(getattr(node, 'interface', None)):
+        return resolve_contract(node)
+
+    inputs, outputs = collect_face(core, node)
+    if not inputs and not outputs:
+        return None
+
+    documented = None
+    if isinstance(node, Link) and core is not None:
+        address = node.address
+        if isinstance(address, Protocol):
+            address = address._default
+        canonical = normalize_address(address)
+        if isinstance(canonical, dict):
+            edge_class = getattr(core, 'link_registry', {}).get(
+                canonical.get('data'))
+            if edge_class is not None:
+                try:
+                    documented = resolve_contract(
+                        edge_class(node.config if isinstance(
+                            node.config, dict) else {}, core))
+                except Exception:
+                    documented = None
+
+    contract = copy.deepcopy(documented) if documented else ProcessContract()
+    contract.face = {'inputs': dict(inputs), 'outputs': dict(outputs)}
+    return contract
+
+
+def contract_admits(core, contract, filler):
+    """Does ``filler`` satisfy ``contract``? Returns ``(ok, reason)``.
+
+    The typed core decides conformance; ``narrow`` amendments may add
+    predicates that must also hold. Because narrowing only ever adds
+    requirements, this stays monotone — see :func:`~bigraph_schema.contract.amend`.
+    """
+    ok, reason = face_conforms(core, contract.face, filler)
+    if not ok:
+        return ok, reason
+
+    for index, predicate in enumerate(contract.predicates()):
+        try:
+            satisfied = predicate(core, filler)
+        except Exception as error:
+            return False, f'contract predicate {index} raised: {error}'
+        if not satisfied:
+            return False, f'filler fails contract predicate {index}'
+
+    return True, None
+
+
 def face_conforms(core, face, filler):
     """Structural subtyping of faces (the composition law, made typed).
 
@@ -711,12 +795,19 @@ def face_conforms(core, face, filler):
     is not — that is what makes a site reusable across processes of the
     same shape.
 
+    ``face`` may be a ``Link`` schema (``_inputs``/``_outputs``) or a
+    contract's typed core (``{'inputs': …, 'outputs': …}``) — the same two
+    spellings of one thing.
+
     Returns ``(ok, reason)``.
     """
     provided = dict(zip(("inputs", "outputs"), collect_face(core, filler)))
 
     for direction, port_key in (('inputs', '_inputs'), ('outputs', '_outputs')):
-        required = getattr(face, port_key, None)
+        if isinstance(face, dict):
+            required = face.get(direction)
+        else:
+            required = getattr(face, port_key, None)
         if not isinstance(required, dict):
             continue
         for port, port_schema in required.items():
@@ -752,9 +843,11 @@ def admits_why(core, site, filler):
             return bool(ok), None if ok else (
                 f'sort {sort!r} rejected the filler')
 
-    face = core.access(sort)
-    if isinstance(face, Link):
-        return face_conforms(core, face, filler)
+    # A sort that names an interface is a *contract*: the typed face decides
+    # conformance, and any narrowing amendment adds to it.
+    contract = contract_of(core, site)
+    if contract is not None:
+        return contract_admits(core, contract, filler)
 
     if core.check(sort, filler):
         return True, None

--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -197,9 +197,9 @@ def compose(outer, inner):
       the corresponding root (top-level key) from ``inner``. Sites
       are matched to roots by index (0th site ↔ 0th root, etc.).
     - **Link composition**: for each outer name of ``inner`` that
-      matches an inner name of ``outer`` (by port name), create a
-      wire connecting the inner Link's output port to the path that
-      the outer Link's input port would read from.
+      matches an inner name of ``outer`` (by port name), **join** the
+      two ports — wire *both* ends to one shared store, so the ports
+      meet the way ``realize`` resolves them. See ``_join_names``.
 
     Currently handles: ground schemas (no Sites, all ports wired) and
     the identity cases. Raises ``NotImplementedError`` for cases not
@@ -230,31 +230,85 @@ def compose(outer, inner):
 
     result = copy.deepcopy(outer)
 
-    # Replace each site with the corresponding root from inner
+    # Replace each site with the corresponding root from inner, recording
+    # where each root landed so inner paths can be rebased into the
+    # composed tree's coordinates.
+    rebase = {}
     for (site_path, _site), root_key in zip(site_list, root_keys):
         if root_key not in inner:
             raise ValueError(
                 f'compose: inner schema missing root {root_key!r}')
         filler = copy.deepcopy(inner[root_key])
         _set_at_path(result, site_path, filler)
+        rebase[root_key] = tuple(site_path)
 
-    # --- Link composition: wire matching names ---
+    # --- Link composition: join matching names ---
     # inner's outer names → ports on inner's Links whose outputs are
     # unwired. outer's inner names → ports on outer's Links whose
-    # inputs are unwired. If port names match, create the connection.
+    # inputs are unwired. Matching names name the same link.
     for port_name, inner_link_path in inner_outer._names.items():
         if port_name in outer_inner._names:
-            outer_link_path = outer_inner._names[port_name]
-            # Wire inner's output → the path that outer's input reads
-            # from. For now: wire inner's output to the default path
-            # (the port name itself, relative to the inner link).
-            outer_link = _get_at_path(result, outer_link_path)
-            if isinstance(outer_link, Link):
-                if isinstance(outer_link.inputs, Wires):
-                    outer_link.inputs = {}
-                outer_link.inputs[port_name] = list(inner_link_path) + [port_name]
+            _join_names(
+                result,
+                port_name,
+                outer_link_path=outer_inner._names[port_name],
+                inner_link_path=inner_link_path,
+                rebase=rebase)
 
     return result
+
+
+def _join_names(result, port_name, outer_link_path, inner_link_path, rebase):
+    """Join an outer name of the filler to the inner name of the context.
+
+    Milner joins the two faces at a single link; in this model a link is
+    realized as a **store path**, so joining means wiring *both* ports to
+    one shared store.
+
+    Wires are relative to a link's parent store (``realize.port_merges``
+    resolves a wire as ``link_path[:-1] + wire``) and cannot ascend, so:
+
+    - the shared store is the filler link's own default output store —
+      ``<filler link's parent>/<port_name>`` — which the filler reaches
+      with the plain relative wire ``[port_name]``;
+    - the context link reaches it by descending from its own parent, which
+      is possible exactly when that parent contains the filled site.
+
+    ``rebase`` maps each of ``inner``'s root keys to the site path its
+    contents were substituted into, so the filler link's path can be
+    expressed in the composed tree.
+    """
+    outer_link = _get_at_path(result, outer_link_path)
+    if not isinstance(outer_link, Link):
+        return
+
+    # Rebase the filler link's path: composition splices a root's
+    # *contents* at the site, so the root key itself disappears.
+    root_key = inner_link_path[0]
+    if root_key not in rebase:
+        return
+    composed_link_path = rebase[root_key] + tuple(inner_link_path[1:])
+
+    store_path = composed_link_path[:-1] + (port_name,)
+
+    outer_parent = tuple(outer_link_path[:-1])
+    if store_path[:len(outer_parent)] != outer_parent:
+        raise ValueError(
+            f'compose: cannot join name {port_name!r} — wires are relative '
+            f'to a link\'s parent and cannot ascend, but the link at '
+            f'{outer_link_path} would have to reach {store_path}. Place the '
+            f'site inside the consuming link\'s parent, or wire the port '
+            f'explicitly before composing.')
+
+    inner_link = _get_at_path(result, composed_link_path)
+    if isinstance(inner_link, Link):
+        if isinstance(inner_link.outputs, Wires):
+            inner_link.outputs = {}
+        inner_link.outputs[port_name] = [port_name]
+
+    if isinstance(outer_link.inputs, Wires):
+        outer_link.inputs = {}
+    outer_link.inputs[port_name] = list(store_path[len(outer_parent):])
 
 
 # ── Tensor product ──────────────────────────────────────────────────

--- a/bigraph_schema/assembly.py
+++ b/bigraph_schema/assembly.py
@@ -182,7 +182,7 @@ def identity(interface):
 # ── Composition ─────────────────────────────────────────────────────
 
 
-def compose(outer, inner):
+def compose(outer, inner, core=None):
     """Compose ``outer ∘ inner``: substitute ``inner``'s roots into
     ``outer``'s Sites, and wire matching port names.
 
@@ -200,6 +200,13 @@ def compose(outer, inner):
       matches an inner name of ``outer`` (by port name), **join** the
       two ports — wire *both* ends to one shared store, so the ports
       meet the way ``realize`` resolves them. See ``_join_names``.
+
+    Place composition is exactly :func:`fill_sites` with positionally
+    matched bindings — Milner's sites are anonymous, so they are paired
+    with ``inner``'s roots by index rather than by name; both routes share
+    one substitution (``_fill_at_paths``). ``core`` is only needed when a
+    site is *sorted* (so ``admits`` can check the filler); plain Milner
+    composition over unsorted sites needs none.
 
     Currently handles: ground schemas (no Sites, all ports wired) and
     the identity cases. Raises ``NotImplementedError`` for cases not
@@ -228,19 +235,21 @@ def compose(outer, inner):
             f'compose: outer has {len(site_list)} sites but inner has '
             f'{len(root_keys)} roots — faces must match')
 
-    result = copy.deepcopy(outer)
-
     # Replace each site with the corresponding root from inner, recording
     # where each root landed so inner paths can be rebased into the
     # composed tree's coordinates.
+    filling = {}
     rebase = {}
-    for (site_path, _site), root_key in zip(site_list, root_keys):
+    for index, ((site_path, site), root_key) in enumerate(
+            zip(site_list, root_keys)):
         if root_key not in inner:
             raise ValueError(
                 f'compose: inner schema missing root {root_key!r}')
-        filler = copy.deepcopy(inner[root_key])
-        _set_at_path(result, site_path, filler)
+        filling[tuple(site_path)] = (
+            site_path[-1] if site_path else index, site, inner[root_key])
         rebase[root_key] = tuple(site_path)
+
+    result = _fill_at_paths(core, outer, filling)
 
     # --- Link composition: join matching names ---
     # inner's outer names → ports on inner's Links whose outputs are
@@ -558,6 +567,206 @@ def validate_sorting(schema, sorting, path=()):
         walk(schema, (), None)
 
     return violations
+
+
+# ── The filling discipline: admits ──────────────────────────────────
+# Milner's sorting constrains a bigraph in two ways that this module
+# keeps as two named relations, because they are different relations
+# that merely share an arity:
+#
+#   formation(parent_sort, child_sort)  — NESTING. May this child live
+#       inside this parent? Policed by ``validate_sorting`` over
+#       parent/child pairs, AFTER substitution.
+#   admits(core, site, filler)          — FILLING. May this filler close
+#       this hole? Checked BEFORE substitution, while the site — and so
+#       its ``_sort`` — still exists. Once a site is filled there is no
+#       site anymore, which is exactly why ``formation`` cannot do this
+#       job.
+
+
+def collect_face(node):
+    """Collect a filler's **outer face** — the ports it declares.
+
+    Returns an ``(inputs, outputs)`` pair of port-type maps. An ``Edge``
+    instance reports its own via ``interface()`` (``edge.py``); a ``Link``
+    reports ``_inputs``/``_outputs``; a subtree reports the union of the
+    Links it contains. Declared ports are used regardless of wiring — a
+    filler exposes its interface whether or not it is internally wired.
+    """
+    inputs = {}
+    outputs = {}
+
+    interface = getattr(node, 'interface', None)
+    if callable(interface):
+        face = interface() or {}
+        return dict(face.get('inputs') or {}), dict(face.get('outputs') or {})
+
+    def walk(subnode):
+        if isinstance(subnode, Link):
+            if isinstance(subnode._inputs, dict):
+                inputs.update(subnode._inputs)
+            if isinstance(subnode._outputs, dict):
+                outputs.update(subnode._outputs)
+        elif isinstance(subnode, dict):
+            if subnode.get('_type') == 'link':
+                if isinstance(subnode.get('_inputs'), dict):
+                    inputs.update(subnode['_inputs'])
+                if isinstance(subnode.get('_outputs'), dict):
+                    outputs.update(subnode['_outputs'])
+                return
+            for key, child in subnode.items():
+                if isinstance(key, str) and not key.startswith('_'):
+                    walk(child)
+
+    walk(node)
+    return inputs, outputs
+
+
+def face_conforms(core, face, filler):
+    """Structural subtyping of faces (the composition law, made typed).
+
+    The filler must provide **every** port the face requires, at a type
+    that ``core.resolve`` accepts. Over-providing is fine; under-providing
+    is not — that is what makes a site reusable across processes of the
+    same shape.
+
+    Returns ``(ok, reason)``.
+    """
+    provided = dict(zip(('inputs', 'outputs'), collect_face(filler)))
+
+    for direction, port_key in (('inputs', '_inputs'), ('outputs', '_outputs')):
+        required = getattr(face, port_key, None)
+        if not isinstance(required, dict):
+            continue
+        for port, port_schema in required.items():
+            if port not in provided[direction]:
+                return False, (
+                    f'filler does not provide {direction[:-1]} port '
+                    f'{port!r} (has {sorted(provided[direction])})')
+            try:
+                core.resolve(port_schema, provided[direction][port])
+            except Exception as error:
+                return False, (
+                    f'{direction[:-1]} port {port!r} does not resolve: '
+                    f'{error}')
+
+    return True, None
+
+
+def admits_why(core, site, filler):
+    """As :func:`admits`, but returns ``(ok, reason)`` so callers can say
+    *why* a filler was rejected."""
+    sort = getattr(site, '_sort', '') or ''
+    if not sort:
+        return True, None          # an unsorted hole — pure Milner
+
+    if core is None:
+        return False, (
+            f'site is sorted {sort!r} but no core was supplied to check it')
+
+    if isinstance(sort, str):
+        admits_fn = getattr(core, 'sort_registry', {}).get(sort)
+        if admits_fn is not None:
+            ok = admits_fn(core, site, filler)
+            return bool(ok), None if ok else (
+                f'sort {sort!r} rejected the filler')
+
+    face = core.access(sort)
+    if isinstance(face, Link):
+        return face_conforms(core, face, filler)
+
+    if core.check(sort, filler):
+        return True, None
+    return False, f'value does not satisfy sort {sort!r}'
+
+
+def admits(core, site, filler):
+    """Is ``filler`` an admissible filling for this sorted site?
+
+    Checked BEFORE substitution (see the section note above). An unsorted
+    site admits anything. A sort registered via ``core.register_sort``
+    decides for itself. A sort that names a **face** (``link[in, out]``,
+    or a link literal) is decided by structural conformance
+    (:func:`face_conforms`); any other sort is a value type, decided by
+    ``core.check``.
+    """
+    ok, _reason = admits_why(core, site, filler)
+    return ok
+
+
+# ── fill — the one substitution primitive ───────────────────────────
+
+
+def collect_sites(body):
+    """Map each open site's **name** to its path.
+
+    A site's name is its key in the place graph — the same convention
+    ``instantiate`` and ``Match.bindings`` already use. Raises when one
+    name is ambiguous across two paths, since bindings address sites by
+    name.
+    """
+    sites = {}
+    for path, site in interfaces(body)[0]._places:
+        name = path[-1] if path else ''
+        if name in sites:
+            raise ValueError(
+                f'fill: site name {name!r} is ambiguous — it appears at '
+                f'{sites[name][0]} and at {path}')
+        sites[name] = (path, site)
+    return sites
+
+
+def _fill_at_paths(core, body, filling):
+    """The substitution itself, shared by every way of naming a site.
+
+    ``filling`` maps a site's **path** to ``(label, site, filler)``. Each
+    filler is checked with :func:`admits` *before* substitution — while the
+    site still exists — and a rejection is a fill error naming the site.
+    Paths not in ``filling`` are left open.
+    """
+    result = copy.deepcopy(body)
+
+    for path, (label, site, filler) in filling.items():
+        ok, reason = admits_why(core, site, filler)
+        if not ok:
+            raise ValueError(
+                f'fill: filler rejected for site {label!r} at {path}: '
+                f'{reason}')
+        _set_at_path(result, path, copy.deepcopy(filler))
+
+    return result
+
+
+def fill_sites(core, body, bindings):
+    """Substitute fillers into named open sites — **the** primitive.
+
+    ``bindings`` maps a site's name to its filler. Sites with no binding
+    fall back to the site's ``_default`` if it has one and are otherwise
+    **left open** — a partially filled document is still a document, which
+    is what lets filling be incremental.
+
+    Filling independent sites commutes: each binding is applied at its own
+    path, so the result does not depend on the order of ``bindings``.
+    """
+    sites = collect_sites(body)
+
+    unknown = set(bindings) - set(sites)
+    if unknown:
+        raise ValueError(
+            f'fill: no such site(s): {sorted(unknown)} '
+            f'(open sites: {sorted(sites)})')
+
+    filling = {}
+    for name, (path, site) in sites.items():
+        if name in bindings:
+            filler = bindings[name]
+        elif getattr(site, '_default', None) is not None:
+            filler = site._default
+        else:
+            continue                    # left open, still a site
+        filling[path] = (name, site, filler)
+
+    return _fill_at_paths(core, body, filling)
 
 
 # ── Binding / link locality ─────────────────────────────────────────

--- a/bigraph_schema/contract.py
+++ b/bigraph_schema/contract.py
@@ -38,9 +38,66 @@ _DIST_NAMES = (
 _MATH_RE = re.compile(r"[=~≈←≥≤∑∏]|\b(?:" + _DIST_NAMES + r")\b")
 
 
+#: Documentary fields — ``annotate`` may touch these and nothing else.
+ANNOTATABLE = (
+    'summary', 'description', 'inputs', 'outputs', 'config',
+    'math', 'symbols', 'assumptions', 'references')
+
+
+class AmendmentError(Exception):
+    """An amendment that would make a contract unsound or looser."""
+
+
+@dataclass
+class Amendment:
+    """One ordered, provenance-carrying refinement of a contract.
+
+    ``op`` is **``narrow``** (tighten the face, or add a predicate) or
+    **``annotate``** (refine documentation). There is deliberately no
+    ``extend``: a contract may get stricter and better-documented as it flows
+    down through composition and filling, never looser and never gain ports
+    it did not require. That is what keeps amendment *monotone*, and so keeps
+    ``admits`` sound.
+    """
+
+    op: str
+    target: str = ""
+    detail: dict = field(default_factory=dict)
+    by: str = ""
+    when: str = ""
+    why: str = ""
+
+    def to_dict(self):
+        detail = {
+            key: (value if _is_jsonish(value) else repr(value))
+            for key, value in (self.detail or {}).items()}
+        return {'op': self.op, 'target': self.target, 'detail': detail,
+                'by': self.by, 'when': self.when, 'why': self.why}
+
+
+def _is_jsonish(value):
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return True
+    if isinstance(value, (list, tuple)):
+        return all(_is_jsonish(item) for item in value)
+    if isinstance(value, dict):
+        return all(_is_jsonish(item) for item in value.values())
+    return False
+
+
 @dataclass
 class ProcessContract:
     """A structured superset of ``Edge.description``.
+
+    A contract is the full interface spec of an **edge or a site**, and
+    ``face`` is its machine-checkable **typed core** — the part ``admits``
+    reads. The remaining fields are the documented meaning around that same
+    interface. They are not two objects: the face is the typed projection of
+    one contract.
+
+    Note the two senses of "inputs" here, kept deliberately separate:
+    ``face['inputs']`` maps a port to its **type** (checked), while
+    ``inputs`` maps a port to its **prose semantics** (documentation only).
 
     All mutable fields use ``default_factory`` so instances never share state.
     """
@@ -54,10 +111,29 @@ class ProcessContract:
     symbols: dict = field(default_factory=dict)
     assumptions: list = field(default_factory=list)
     references: list = field(default_factory=list)
+    face: dict = field(default_factory=lambda: {'inputs': {}, 'outputs': {}})
+    amendments: list = field(default_factory=list)
+
+    def face_ports(self, direction):
+        """The typed core's ports for ``'inputs'`` or ``'outputs'``."""
+        found = (self.face or {}).get(direction)
+        return found if isinstance(found, dict) else {}
+
+    def predicates(self):
+        """Every predicate contributed by a ``narrow`` amendment."""
+        found = []
+        for amendment in self.amendments:
+            predicate = (amendment.detail or {}).get('predicate')
+            if callable(predicate):
+                found.append(predicate)
+        return found
 
     def to_dict(self):
         """Return a JSON-safe plain-``dict`` representation."""
-        return asdict(self)
+        result = asdict(self)
+        result['amendments'] = [
+            amendment.to_dict() for amendment in self.amendments]
+        return result
 
     @classmethod
     def from_description(cls, text):
@@ -117,6 +193,83 @@ class ProcessContract:
         return merged
 
 
+def _as_amendment(amendment):
+    if isinstance(amendment, Amendment):
+        return amendment
+    if isinstance(amendment, dict):
+        try:
+            return Amendment(**amendment)
+        except TypeError as error:
+            raise AmendmentError(f'malformed amendment: {error}') from None
+    raise AmendmentError(f'not an amendment: {amendment!r}')
+
+
+def amend(contract, amendment):
+    """Append one amendment to ``contract``, returning a **new** contract.
+
+    Pure and append-only: the input is never mutated and no amendment is ever
+    dropped, so a contract carries the full record of how its interface
+    evolved — each entry with its ``by``/``when``/``why``.
+
+    - ``narrow`` tightens the typed core: it may add ports the face did not
+      require, and may add a ``predicate`` that a filler must also satisfy.
+      It may **not** redefine a port the face already requires — replacing a
+      port's type could widen what conforms, which would break monotonicity —
+      and it may not remove one.
+    - ``annotate`` refines documentation only, leaving admissibility exactly
+      as it was.
+    - anything else (notably ``extend``) is refused: a contract may become
+      stricter and better-documented, never looser.
+
+    **Monotonicity.** Because ``narrow`` only ever adds required ports and
+    conjunctive predicates, every filler admissible under the amended
+    contract was admissible under the original. ``admits`` therefore stays
+    sound as a contract flows down through composition and filling.
+    """
+    amendment = _as_amendment(amendment)
+    amended = copy.deepcopy(contract)
+    detail = amendment.detail or {}
+
+    if amendment.op == 'narrow':
+        for direction in ('inputs', 'outputs'):
+            added = detail.get(direction)
+            if not isinstance(added, dict):
+                continue
+            existing = amended.face_ports(direction)
+            for port, port_type in added.items():
+                if port in existing and existing[port] != port_type:
+                    raise AmendmentError(
+                        f'narrow may not redefine the {direction[:-1]} port '
+                        f'{port!r} ({existing[port]!r} -> {port_type!r}): '
+                        f'replacing a port type can widen what conforms. '
+                        f'Add a new port or a predicate instead.')
+            amended.face = dict(amended.face or {})
+            amended.face[direction] = {**existing, **added}
+
+    elif amendment.op == 'annotate':
+        for key, value in detail.items():
+            if key not in ANNOTATABLE:
+                raise AmendmentError(
+                    f'annotate may only touch documentation '
+                    f'{ANNOTATABLE}, not {key!r}')
+            current = getattr(amended, key)
+            if isinstance(current, dict) and isinstance(value, dict):
+                setattr(amended, key, {**current, **value})
+            elif isinstance(current, list) and isinstance(value, list):
+                setattr(amended, key, [*current, *value])
+            else:
+                setattr(amended, key, value)
+
+    else:
+        raise AmendmentError(
+            f'unsupported amendment op {amendment.op!r} — a contract may '
+            f'only be narrowed or annotated, so that it can get stricter '
+            f'and better documented but never looser')
+
+    amended.amendments = [*amended.amendments, amendment]
+    return amended
+
+
 def _as_contract(declared):
     """Coerce a declared ``contract`` attribute into a ``ProcessContract``.
 
@@ -154,19 +307,48 @@ def resolve_contract(instance):
 
         contract = _as_contract(declared)
         if contract is not None:
-            return contract.merged_with_description(desc or "")
+            resolved = contract.merged_with_description(desc or "")
+        elif desc:
+            resolved = ProcessContract.from_description(desc)
+        else:
+            # Docstring fallback — but ignore a docstring merely inherited
+            # from ``object`` (so a bare ``object()`` resolves to None, while
+            # a class with its own docstring resolves).
+            doc = inspect.getdoc(type(instance))
+            resolved = (
+                ProcessContract.from_description(doc)
+                if doc and doc != inspect.getdoc(object)
+                else None)
 
-        if desc:
-            derived = ProcessContract.from_description(desc)
-            if derived is not None:
-                return derived
-
-        # Docstring fallback — but ignore a docstring merely inherited from
-        # ``object`` (so a bare ``object()`` resolves to None, while a class
-        # with its own docstring resolves).
-        doc = inspect.getdoc(type(instance))
-        if doc and doc != inspect.getdoc(object):
-            return ProcessContract.from_description(doc)
-        return None
+        return _with_declared_face(instance, resolved)
     except Exception:
         return None
+
+
+def _with_declared_face(instance, contract):
+    """Fill an edge's typed core from its own ``interface()``.
+
+    The face is the contract's machine-checkable projection, so an edge that
+    reports ports carries them on its contract — an authored ``face`` wins.
+    """
+    interface = getattr(instance, 'interface', None)
+    if not callable(interface):
+        return contract
+
+    try:
+        face = interface() or {}
+    except Exception:
+        return contract
+
+    declared = {
+        'inputs': dict(face.get('inputs') or {}),
+        'outputs': dict(face.get('outputs') or {})}
+    if not declared['inputs'] and not declared['outputs']:
+        return contract
+
+    if contract is None:
+        return ProcessContract(face=declared)
+    if not contract.face_ports('inputs') and not contract.face_ports('outputs'):
+        contract = copy.deepcopy(contract)
+        contract.face = declared
+    return contract

--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -149,6 +149,10 @@ class Core:
         self.registry = {}
         self.link_registry = {}
         self.method_registry = {}
+        # sort name -> admits(core, site, filler): the FILLING discipline
+        # (what may close a hole), as opposed to Sorting.formation, which
+        # is the NESTING discipline (what may live inside what).
+        self.sort_registry = {}
         # ``_access_cache`` is keyed by ``id(dict)`` and holds the dict
         # witness alive (so id reuse after GC is detected). Fresh
         # short-lived dicts produced per-tick (projection schemas,
@@ -233,6 +237,33 @@ class Core:
 
     def register_method(self, key, data):
         self.method_registry[key] = data
+
+    def register_sort(self, key, admits):
+        """Register the **filling** discipline for a sort.
+
+        ``admits(core, site, filler) -> bool`` decides whether a filler may
+        close a site of this sort. Distinct from ``Sorting.formation``,
+        which is the *nesting* discipline (see ``assembly``); a sort with no
+        registered ``admits`` falls back to face-conformance when it names a
+        link and to ``check`` otherwise.
+        """
+        self.sort_registry[key] = admits
+
+    def admits(self, site, filler):
+        """Is ``filler`` an admissible filling for this sorted site?"""
+        from bigraph_schema.assembly import admits
+        return admits(self, site, filler)
+
+    def fill_sites(self, body, bindings):
+        """Substitute fillers into ``body``'s named open sites.
+
+        The one substitution primitive: ``admits``-checked, order-independent
+        across independent sites, and leaving unbound sites open so a
+        partially filled document is still a document. Note this is **not**
+        ``Core.bind``, which binds a logical key (a jump) to a target.
+        """
+        from bigraph_schema.assembly import fill_sites
+        return fill_sites(self, body, bindings)
 
     def call_method(self, key, *args, **kwargs):
         method = self.method_registry.get(key)

--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -153,6 +153,9 @@ class Core:
         # (what may close a hole), as opposed to Sorting.formation, which
         # is the NESTING discipline (what may live inside what).
         self.sort_registry = {}
+        # sort name -> ProcessContract: the interface a site of that sort
+        # *requires*, amendments included.
+        self.contract_registry = {}
         # ``_access_cache`` is keyed by ``id(dict)`` and holds the dict
         # witness alive (so id reuse after GC is detected). Fresh
         # short-lived dicts produced per-tick (projection schemas,
@@ -248,6 +251,26 @@ class Core:
         link and to ``check`` otherwise.
         """
         self.sort_registry[key] = admits
+
+    def register_contract(self, key, contract):
+        """Register the contract a sort names.
+
+        A site sorted with this name then requires that contract — including
+        any amendments it carries — so a narrowed or better-documented
+        interface can be shared by name rather than restated at each site.
+        """
+        self.contract_registry[key] = contract
+
+    def describe_contract(self, node):
+        """The contract of an edge **or a site** — the face as typed core,
+        plus its documented meaning and amendment history.
+
+        For a site this is the contract it *requires*; for an edge, the one
+        it provides. ``Edge.describe_contract()`` remains the per-instance
+        spelling of the same thing.
+        """
+        from bigraph_schema.assembly import contract_of
+        return contract_of(self, node)
 
     def admits(self, site, filler):
         """Is ``filler`` an admissible filling for this sorted site?"""

--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -265,6 +265,19 @@ class Core:
         from bigraph_schema.assembly import fill_sites
         return fill_sites(self, body, bindings)
 
+    def replicate(self, template, counts=None):
+        """Expand marked regions into keyed copies (the cardinality
+        reaction), before any filling."""
+        from bigraph_schema.assembly import replicate
+        return replicate(template, counts)
+
+    def build(self, template, overrides=None):
+        """Replicate, fill, default, and check groundness — returns a
+        runnable ``(schema, state)``. Convenience over ``replicate`` +
+        ``fill_sites`` + ``fill``; not a primitive."""
+        from bigraph_schema.assembly import build
+        return build(self, template, overrides)
+
     def call_method(self, key, *args, **kwargs):
         method = self.method_registry.get(key)
         if method is None:

--- a/bigraph_schema/methods/default.py
+++ b/bigraph_schema/methods/default.py
@@ -221,17 +221,36 @@ def default(schema: Protocol):
             'protocol': 'local',
             'data': 'edge'}
 
+def _default_materialized(value, fallback):
+    """Default a link field that ``access`` may leave **materialized**.
+
+    ``address`` and the ``inputs``/``outputs`` wires are values, not schemas:
+    a declared address survives as a ``Protocol``'s ``_default`` and declared
+    wires survive as a plain ``{port: path}`` dict. Walking either as a schema
+    reaches a raw string or a path list, which no ``default`` dispatch
+    accepts — so a link that declared an address or its wiring could not be
+    defaulted at all. Only an unmaterialized field goes through ``default``.
+    """
+    if isinstance(value, dict):
+        return value or fallback
+    if isinstance(value, str):
+        return value
+    return default(value) or fallback
+
+
 def default_link(schema: Link):
-    if schema._default: 
+    if schema._default:
         return schema._default
     else:
         return {
-            'address': default(schema.address) or 'local:edge',
+            'address': _default_materialized(schema.address, 'local:edge'),
             'config': default(schema.config) or {},
             '_inputs': schema._inputs,
             '_outputs': schema._outputs,
-            'inputs': default(schema.inputs) or default_wires(schema._inputs),
-            'outputs': default(schema.outputs) or default_wires(schema._outputs)}
+            'inputs': _default_materialized(
+                schema.inputs, default_wires(schema._inputs)),
+            'outputs': _default_materialized(
+                schema.outputs, default_wires(schema._outputs))}
 
 @dispatch
 def default(schema: Link):

--- a/bigraph_schema/methods/handle_parameters.py
+++ b/bigraph_schema/methods/handle_parameters.py
@@ -37,8 +37,10 @@ from bigraph_schema.schema import (
     Schema,
     Link,
     Object,
+    Protocol,
     schema_dtype,
     is_schema_field,
+    normalize_address,
 )
 
 # aligning parameters takes them from positioned arguments and gives them keys
@@ -253,9 +255,35 @@ def reify_schema(core, schema: Union, parameters):
     return replace(schema, **parameters)
 
 
+def access_address(core, address):
+    """Compile a link's ``address`` into a ``Protocol`` **schema node**.
+
+    The address itself is a value, so it rides on the node's ``_default`` —
+    which is exactly the shape ``realize`` produces for the same link, and
+    what ``default``/``realize_link`` already read. Routing it through
+    ``core.access`` instead would parse it as a type expression (see
+    ``normalize_address``).
+    """
+    if isinstance(address, Protocol):
+        return address
+
+    canonical = normalize_address(address)
+    if not isinstance(canonical, dict) or 'protocol' not in canonical:
+        return core.access(address)
+
+    try:
+        node = core.access(canonical['protocol'])
+    except Exception:
+        node = None
+    if not isinstance(node, Protocol):
+        node = Protocol()
+
+    return replace(node, _default=canonical)
+
+
 def reify_schema_link(core, schema, parameters):
     if 'address' in parameters:
-        schema.address = core.access(parameters['address'])
+        schema.address = access_address(core, parameters['address'])
     if 'config' in parameters:
         schema.config = core.access(parameters['config'])
     if 'inputs' in parameters:

--- a/bigraph_schema/methods/realize.py
+++ b/bigraph_schema/methods/realize.py
@@ -42,6 +42,7 @@ from bigraph_schema.schema import (
     Wires,
     Protocol,
     LocalProtocol,
+    normalize_address,
     Schema,
     Link,
     Object,
@@ -610,18 +611,7 @@ def realize_link(core, schema: Link, encode, path=()):
     # rebuilt with the new wiring after realization.
     core.invalidate_link(path)
 
-    address = encode.get('address', 'local:edge')
-
-    if isinstance(address, str):
-        if ':' not in address:
-            protocol = 'local'
-            data = address
-        else:
-            protocol, data = address.split(':', 1)
-
-        address = {
-            'protocol': protocol,
-            'data': data}
+    address = normalize_address(encode.get('address', 'local:edge'))
 
     if 'instance' in encode:
         # Instance already exists — skip instantiation but still

--- a/bigraph_schema/methods/realize.py
+++ b/bigraph_schema/methods/realize.py
@@ -716,13 +716,19 @@ def realize_link(core, schema: Link, encode, path=()):
         else:
             subschema = getattr(schema, port)
 
-            subschema._default = encode[port]
-            wires_schema, wires_state, submerges = realize(core, subschema, encode[port], path+(port,))
-            if wires_state is None:
-                decode[port] = default_wires(port_schema)
+            if isinstance(subschema, dict):
+                # ``access`` materializes declared wires as a plain
+                # ``{port: path}`` dict, which carries no ``_default`` to
+                # stamp and is already the value realize would produce.
+                decode[port] = encode[port]
             else:
-                decode[port] = wires_state
-            merges += submerges
+                subschema._default = encode[port]
+                wires_schema, wires_state, submerges = realize(core, subschema, encode[port], path+(port,))
+                if wires_state is None:
+                    decode[port] = default_wires(port_schema)
+                else:
+                    decode[port] = wires_state
+                merges += submerges
 
         submerges = port_merges(
             core,
@@ -741,7 +747,12 @@ def realize_link(core, schema: Link, encode, path=()):
             if has_instance and key in ('config', 'instance'):
                 decode[key] = value
             elif hasattr(schema, key):
-                getattr(schema, key)._default = value
+                field_schema = getattr(schema, key)
+                if hasattr(field_schema, '_default'):
+                    field_schema._default = value
+                # Otherwise the field is materialized — ``access`` left a
+                # plain dict/string that already *is* the value, so there is
+                # no schema node to stamp a default onto.
             else:
                 attr, decode[key], submerges = realize(
                     core, {}, value, path+(key,))

--- a/bigraph_schema/methods/serialize.py
+++ b/bigraph_schema/methods/serialize.py
@@ -86,8 +86,15 @@ def render(schema: Empty, defaults=False):
 # metadata carried on the schema.
 
 def _render_bigraph_structural(schema, type_name, defaults=False):
-    if getattr(schema, '_sort', ''):
-        result = {'_type': type_name, '_sort': schema._sort}
+    sort = getattr(schema, '_sort', '')
+    if sort:
+        # ``_sort`` is a schema key, so ``access`` resolves a sort given as a
+        # type — a value type, or a link literal naming a face — into a schema
+        # node. Render it back so a sorted site (and so a template) survives
+        # the round trip to an on-disk document.
+        if isinstance(sort, Node):
+            sort = render(sort, defaults=defaults)
+        result = {'_type': type_name, '_sort': sort}
     else:
         result = type_name
     return wrap_default(schema, result) if defaults else result

--- a/bigraph_schema/methods/serialize.py
+++ b/bigraph_schema/methods/serialize.py
@@ -32,6 +32,7 @@ from bigraph_schema.schema import (
     DivideReset,
     DivideShare,
     LineageSeed,  # for render dispatch only
+    Protocol,
     List,
     Set,
     Map,
@@ -416,20 +417,56 @@ def render(schema: Wires, defaults=False):
     result = 'wires'
     return wrap_default(schema, result) if defaults else result
 
+_LINK_FIELD_DEFAULTS = None
+
+
+def _link_field_defaults():
+    """The value each ``Link`` field carries when nothing was declared."""
+    global _LINK_FIELD_DEFAULTS
+    if _LINK_FIELD_DEFAULTS is None:
+        blank = Link()
+        _LINK_FIELD_DEFAULTS = {
+            name: getattr(blank, name) for name in blank.__dataclass_fields__}
+    return _LINK_FIELD_DEFAULTS
+
+
+@dispatch
+def render(schema: Protocol, defaults=False):
+    """Render a protocol back to the ``protocol:data`` address form.
+
+    A ``Protocol`` node's ``_default`` *is* the address it names (that is
+    what both ``access`` and ``realize`` put there), so rendering the node's
+    schema fields would throw the address away and emit something
+    ``load_protocol`` cannot read. An address-less protocol renders as its
+    bare type name.
+    """
+    address = schema._default
+    if isinstance(address, dict) and 'protocol' in address and 'data' in address:
+        return f"{address['protocol']}:{address['data']}"
+    return _node_type_name(type(schema)) or 'protocol'
+
+
 @dispatch
 def render(schema: Link, defaults=False):
     intermediate = {'_type': 'link'}
 
+    # Only fields that were actually declared are rendered. A link that
+    # never named an address must not emit one: the rendered form is fed
+    # back through ``access``, and a stand-in address would be read as a
+    # real one (and then fail to load as a protocol).
+    blank = _link_field_defaults()
     for field_name in schema.__dataclass_fields__:
         if not is_schema_field(schema, field_name):
             continue
         value = getattr(schema, field_name)
+        if field_name in blank and value == blank[field_name]:
+            continue
         intermediate[field_name] = render(value, defaults=defaults)
 
-    # Compact form for simple links with only core fields
-    if (isinstance(intermediate.get('_inputs'), str)
-            and isinstance(intermediate.get('_outputs'), str)
-            and len(intermediate) <= 5):
+    # Compact form for a link that declares nothing but its ports.
+    if (set(intermediate) == {'_type', '_inputs', '_outputs'}
+            and isinstance(intermediate['_inputs'], str)
+            and isinstance(intermediate['_outputs'], str)):
         result = f'link[{intermediate["_inputs"]},{intermediate["_outputs"]}]'
     else:
         result = intermediate

--- a/bigraph_schema/schema.py
+++ b/bigraph_schema/schema.py
@@ -12,6 +12,32 @@ from dataclasses import dataclass, is_dataclass, field
 NONE_SYMBOL = '__nil__'
 
 
+def normalize_address(address):
+    """Put a link's ``address`` into canonical ``{'protocol', 'data'}`` form.
+
+    An address is a **value**, not a type expression — ``'local:edge'``,
+    ``'edge'``, or an already-canonical dict. It must never be routed
+    through ``Core.access``: ``'local:edge'`` parses under the
+    named-parameter grammar (``name:Type``) and yields ``{'local': 'edge'}``,
+    which nothing downstream can read.
+
+    A string without a protocol defaults to ``local``. Anything that is not
+    a string or a canonical dict is returned unchanged, so callers can tell
+    "not an address" from "an address I normalized".
+    """
+    if isinstance(address, str):
+        if ':' in address:
+            protocol, data = address.split(':', 1)
+        else:
+            protocol, data = 'local', address
+        return {'protocol': protocol, 'data': data}
+
+    if isinstance(address, dict) and 'protocol' in address:
+        return address
+
+    return address
+
+
 def is_schema_field(schema, key):
     """Check whether a _ prefixed key on a schema is a schema field (vs metadata).
 

--- a/tests.py
+++ b/tests.py
@@ -1801,11 +1801,18 @@ def test_fill_rejects_a_shape_mismatched_port(core):
 
 
 def test_fill_value_site_checks_and_rejects(core):
-    """A value-sorted site is decided by ``check``."""
+    """A value-sorted site is decided by ``check``.
+
+    A value is *state*, so filling puts it on the site's sort as that
+    sort's default — the filled tree stays a schema, and ``core.fill``
+    materializes the value later.
+    """
     body = _sorted_body(core, 'float')
 
     filled = core.fill_sites(body, {'model': 3.5})
-    assert filled['study']['model'] == 3.5
+    assert isinstance(filled['study']['model'], Float)
+    assert filled['study']['model']._default == 3.5
+    assert core.fill(filled, {})['study']['model'] == 3.5
 
     with pytest.raises(ValueError, match="site 'model'"):
         core.fill_sites(body, {'model': 'not a float'})
@@ -1816,10 +1823,11 @@ def test_fill_optional_site_falls_back_to_its_default(core):
     body = _sorted_body(core, 'float', _default=1.25)
 
     filled = core.fill_sites(body, {})
-    assert filled['study']['model'] == 1.25
+    assert filled['study']['model']._default == 1.25
 
     # An explicit binding still wins over the default.
-    assert core.fill_sites(body, {'model': 9.0})['study']['model'] == 9.0
+    assert core.fill_sites(
+        body, {'model': 9.0})['study']['model']._default == 9.0
 
 
 def test_fill_unsorted_site_admits_anything(core):
@@ -1834,13 +1842,32 @@ def test_fill_rejects_an_unknown_site_name(core):
         core.fill_sites(body, {'nonexistent': 1.0})
 
 
-def test_fill_rejects_an_ambiguous_site_name(core):
-    """Bindings address sites by name, so a duplicated name is an error."""
+def test_fill_addresses_a_shared_site_name_by_path(core):
+    """A key shared by two sites is not a usable address; the error offers
+    the path form, which addresses each site unambiguously."""
     body = core.access({
         'left': {'hole': {'_type': 'site'}},
         'right': {'hole': {'_type': 'site'}}})
-    with pytest.raises(ValueError, match='ambiguous'):
+
+    with pytest.raises(ValueError, match='more than one site') as raised:
         core.fill_sites(body, {'hole': 1.0})
+    assert 'left/hole' in str(raised.value)
+    assert 'right/hole' in str(raised.value)
+
+    filled = core.fill_sites(body, {'left/hole': 1.0, 'right/hole': 2.0})
+    assert filled['left']['hole'] == 1.0
+    assert filled['right']['hole'] == 2.0
+
+
+def test_fill_rejects_binding_one_site_under_two_addresses(core):
+    """The bare key and the path name the same hole — binding both is a
+    conflict, not a silent last-wins."""
+    body = core.access({'study': {'model': {'_type': 'site'}}})
+
+    assert core.fill_sites(body, {'study/model': 1.0})['study']['model'] == 1.0
+
+    with pytest.raises(ValueError, match='bound twice'):
+        core.fill_sites(body, {'model': 1.0, 'study/model': 2.0})
 
 
 def test_register_sort_overrides_the_default_discipline(core):
@@ -1959,6 +1986,201 @@ def test_non_ground_document_survives_round_trip(core):
     assert not is_ground(round_tripped)
     assert isinstance(round_tripped['study']['model'], Site)
     assert core.render(round_tripped) == rendered
+
+
+# ── cardinality: replication is a reaction ──────────────────────────
+
+
+def _colony(core, **region):
+    """A document with one region marked for replication."""
+    return core.access({'colony': {
+        'cell': dict({'_control': 'replicate'}, **region),
+        'medium': 'float'}})
+
+
+def test_replicate_expands_a_marked_region(core):
+    """n=3 yields three keyed copies of the region's contents."""
+    body = _colony(core, mass='float', genome='string')
+
+    replicated = core.replicate(body, {'cell': 3})
+
+    assert sorted(replicated['colony']) == [
+        'cell_0', 'cell_1', 'cell_2', 'medium']
+    for index in range(3):
+        copy_ = replicated['colony'][f'cell_{index}']
+        assert sorted(copy_) == ['genome', 'mass']
+        assert isinstance(copy_['mass'], Float)
+    # The sibling that was never marked is untouched.
+    assert isinstance(replicated['colony']['medium'], Float)
+
+
+def test_replicate_is_deterministic(core):
+    """Same input and same count → identical structure, every time."""
+    body = _colony(core, mass='float', genome='string')
+    assert core.replicate(body, {'cell': 3}) == core.replicate(body, {'cell': 3})
+
+
+def test_replicate_n_of_one(core):
+    """n=1 yields exactly one copy — still renamed, so the shape of a
+    document does not depend on its count."""
+    replicated = core.replicate(_colony(core, mass='float'), {'cell': 1})
+    assert sorted(replicated['colony']) == ['cell_0', 'medium']
+
+
+def test_replicate_count_defaults_to_the_region(core):
+    """A region may carry its own ``_count``; an override wins."""
+    body = core.access({'colony': {
+        'cell': {'_control': 'replicate', '_count': 2, 'mass': 'float'}}})
+
+    assert sorted(core.replicate(body)['colony']) == ['cell_0', 'cell_1']
+    assert sorted(core.replicate(body, {'cell': 3})['colony']) == [
+        'cell_0', 'cell_1', 'cell_2']
+
+
+def test_replicate_drops_the_mark_so_it_reaches_quiescence(core):
+    """Copies are unmarked, so replication cannot fire on its own output."""
+    from bigraph_schema.assembly import collect_regions
+
+    replicated = core.replicate(_colony(core, mass='float'), {'cell': 2})
+
+    assert collect_regions(replicated) == {}
+    assert core.replicate(replicated, {'cell': 5}) == replicated
+
+
+def test_replicate_materializes_a_per_instance_site(core):
+    """A site inside the region is materialized n times and is fillable
+    per instance — addressed by path, since the copies share its key."""
+    from bigraph_schema.assembly import collect_sites
+
+    body = core.access({'colony': {'cell': {
+        '_control': 'replicate',
+        'seed': {'_type': 'site', '_sort': 'integer'}}}})
+
+    replicated = core.replicate(body, {'cell': 3})
+    addresses = sorted(a for a in collect_sites(replicated) if '/' in a)
+    assert addresses == [
+        'colony/cell_0/seed', 'colony/cell_1/seed', 'colony/cell_2/seed']
+
+    filled = core.fill_sites(replicated, {
+        'colony/cell_0/seed': 1,
+        'colony/cell_1/seed': 2,
+        'colony/cell_2/seed': 3})
+    assert [core.fill(filled, {})['colony'][f'cell_{i}']['seed']
+            for i in range(3)] == [1, 2, 3]
+
+
+def test_replicate_expands_only_the_named_region(core):
+    """Two marked siblings expand independently, each by its own count."""
+    body = core.access({'colony': {
+        'cell': {'_control': 'replicate', 'mass': 'float'},
+        'vessel': {'_control': 'replicate', 'volume': 'float'}}})
+
+    replicated = core.replicate(body, {'cell': 2, 'vessel': 3})
+
+    assert sorted(replicated['colony']) == [
+        'cell_0', 'cell_1', 'vessel_0', 'vessel_1', 'vessel_2']
+    assert 'mass' in replicated['colony']['cell_0']
+    assert 'volume' in replicated['colony']['vessel_0']
+
+
+def test_replicate_rejects_a_bad_count(core):
+    body = _colony(core, mass='float')
+    for bad in (-1, 2.5, 'three'):
+        with pytest.raises(ValueError, match='non-negative int'):
+            core.replicate(body, {'cell': bad})
+
+    from bigraph_schema.assembly import MAX_REPLICAS
+    with pytest.raises(ValueError, match='MAX_REPLICAS'):
+        core.replicate(body, {'cell': MAX_REPLICAS + 1})
+
+
+def test_replicate_rule_is_a_shared_parameter_reaction(core):
+    """The mechanism is Milner's parametric rule: every reactum site
+    instantiates from the *same* redex site (§8.1), which is what makes
+    the copies copies."""
+    from bigraph_schema.assembly import replicate_rule
+
+    rule = replicate_rule('cell', 3)
+    assert set(rule.instantiation.values()) == {'contents'}
+    assert sorted(rule.reactum) == ['cell_0', 'cell_1', 'cell_2']
+
+
+# ── build: the template convenience ─────────────────────────────────
+
+
+def test_build_is_the_litmus_test(core):
+    """A template with a face-sorted model site, a value site, and a
+    replicated region: drop in a conforming process and get a ground,
+    runnable document — no code."""
+    from bigraph_schema.assembly import interfaces
+
+    template = core.access({'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE},
+        'timestep': {'_type': 'site', '_sort': 'float', '_default': 1.0},
+        'seeds': {
+            '_control': 'replicate',
+            'seed': {'_type': 'site', '_sort': 'integer'}}}})
+
+    model = _process(core, {'glucose': 'float'}, {'growth_rate': 'float'})
+
+    schema, state = core.build(template, {
+        'model': model,
+        'seeds': 2,
+        'study/seeds_0/seed': 7,
+        'study/seeds_1/seed': 8})
+
+    assert sorted(schema['study']) == [
+        'model', 'seeds_0', 'seeds_1', 'timestep']
+    assert interfaces(schema)[0]._places == ()      # ground: no open sites
+    assert state['study']['timestep'] == 1.0        # the site's default
+    assert state['study']['seeds_0']['seed'] == 7
+    assert state['study']['seeds_1']['seed'] == 8
+
+
+def test_build_reports_an_unfilled_required_site(core):
+    template = core.access({'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE},
+        'timestep': {'_type': 'site', '_sort': 'float'}}})
+
+    with pytest.raises(ValueError, match='not ground') as raised:
+        core.build(template, {})
+    assert 'study/model' in str(raised.value)
+    assert 'study/timestep' in str(raised.value)
+
+
+def test_build_reports_a_non_conforming_filler(core):
+    template = core.access({'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE}}})
+    wrong = _process(core, {'glucose': 'float'}, {'biomass': 'float'})
+
+    with pytest.raises(ValueError, match="site 'model'"):
+        core.build(template, {'model': wrong})
+
+
+def test_build_of_a_ground_document_is_the_identity_on_shape(core):
+    """A template with no sites and no marks is already a document."""
+    template = core.access({'cell': {'mass': 'float'}})
+    schema, state = core.build(template)
+    assert schema == template
+    assert state == {'cell': {'mass': 0.0}}
+
+
+@pytest.mark.xfail(
+    reason='pre-existing on origin/main: core.access leaves a Link.address '
+           'as a raw str/dict rather than a Protocol, so default/realize '
+           'walk it as a schema and fail. Blocks build() for any filler '
+           'declaring an explicit address.',
+    strict=True)
+def test_build_with_an_addressed_filler(core):
+    template = core.access({'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE}}})
+    addressed = core.access({
+        '_type': 'link',
+        'address': 'local:edge',
+        '_inputs': {'glucose': 'float'},
+        '_outputs': {'growth_rate': 'float'}})
+
+    core.build(template, {'model': addressed})
 
 
 def test_compose_atom(core):

--- a/tests.py
+++ b/tests.py
@@ -2476,6 +2476,224 @@ def test_wired_link_defaults_and_realizes(core):
     assert isinstance(state['p']['instance'], Edge)
 
 
+# ── the contract: face as typed core, plus semantics and amendments ─
+
+
+def _solver_contract():
+    from bigraph_schema.contract import ProcessContract
+    return ProcessContract(
+        summary='Integrates a model.',
+        face={'inputs': {'model': 'string'},
+              'outputs': {'trajectory': 'map[float]'}})
+
+
+class SeededSolver(Edge):
+    """A solver that also consumes a seed."""
+
+    def inputs(self):
+        return {'model': 'string', 'seed': 'integer'}
+
+    def outputs(self):
+        return {'trajectory': 'map[float]'}
+
+
+def _solver_fillers(core):
+    core.register_link('CopasiSolver', CopasiSolver)
+    core.register_link('SeededSolver', SeededSolver)
+    core.register_link('NotASolver', NotASolver)
+    return {
+        name: core.access({'_type': 'link', 'address': f'local:{name}'})
+        for name in ('CopasiSolver', 'SeededSolver', 'NotASolver')}
+
+
+def test_describe_contract_answers_for_a_site(core):
+    """A site's sort *is* a contract — the interface it requires."""
+    site = core.access({'_type': 'site', '_sort': SOLVER_FACE})
+
+    contract = core.describe_contract(site)
+
+    assert sorted(contract.face_ports('inputs')) == ['model']
+    assert sorted(contract.face_ports('outputs')) == ['trajectory']
+
+
+def test_describe_contract_answers_for_an_edge(core):
+    """The same call answers for the thing that fills the hole, and the
+    face is the typed projection of the one contract."""
+    instance = CopasiSolver({}, core)
+
+    contract = core.describe_contract(instance)
+
+    assert contract.face == {
+        'inputs': {'model': 'string'},
+        'outputs': {'trajectory': 'map[float]'}}
+    # The documentary half still comes from the docstring convention.
+    assert 'conforming implementation' in contract.summary
+    # ``Edge.describe_contract()`` is the per-instance spelling of the same.
+    assert instance.describe_contract().face == contract.face
+
+
+def test_amend_is_pure_and_append_only(core):
+    from bigraph_schema.contract import Amendment, amend
+
+    base = _solver_contract()
+    first = amend(base, Amendment(
+        op='narrow', detail={'inputs': {'seed': 'integer'}},
+        by='fable', when='2026-07-30', why='reproducibility'))
+    second = amend(first, Amendment(op='annotate', detail={'summary': 'v2'}))
+
+    # The input is never mutated.
+    assert base.amendments == []
+    assert 'seed' not in base.face_ports('inputs')
+
+    # Every amendment is kept, in order, with its provenance.
+    assert [a.op for a in second.amendments] == ['narrow', 'annotate']
+    assert second.amendments[0].by == 'fable'
+    assert second.amendments[0].why == 'reproducibility'
+
+
+def test_narrow_makes_admits_strictly_stricter(core):
+    """Narrowing adds a required port, so strictly fewer fillers conform."""
+    from bigraph_schema.contract import Amendment, amend
+
+    fillers = _solver_fillers(core)
+    base = _solver_contract()
+    narrowed = amend(base, Amendment(
+        op='narrow', detail={'inputs': {'seed': 'integer'}}))
+
+    core.register_contract('solver', base)
+    core.register_contract('solver_seeded', narrowed)
+    loose = core.access({'_type': 'site', '_sort': 'solver'})
+    strict = core.access({'_type': 'site', '_sort': 'solver_seeded'})
+
+    assert core.admits(loose, fillers['CopasiSolver'])
+    assert core.admits(loose, fillers['SeededSolver'])
+
+    # The one that never took a seed no longer conforms.
+    assert not core.admits(strict, fillers['CopasiSolver'])
+    assert core.admits(strict, fillers['SeededSolver'])
+
+
+def test_narrow_is_monotone(core):
+    """The law that keeps ``admits`` sound: anything admissible under an
+    amended (narrower) contract was admissible under the original."""
+    from bigraph_schema.contract import Amendment, amend
+
+    fillers = _solver_fillers(core)
+    base = _solver_contract()
+
+    amended = base
+    for amendment in (
+            Amendment(op='narrow', detail={'inputs': {'seed': 'integer'}}),
+            Amendment(op='annotate', detail={'summary': 'seeded solver'}),
+            Amendment(op='narrow', detail={
+                'predicate': lambda core, filler: True}),
+    ):
+        amended = amend(amended, amendment)
+
+        core.register_contract('base', base)
+        core.register_contract('amended', amended)
+        before = core.access({'_type': 'site', '_sort': 'base'})
+        after = core.access({'_type': 'site', '_sort': 'amended'})
+
+        for name, filler in fillers.items():
+            if core.admits(after, filler):
+                assert core.admits(before, filler), (
+                    f'{name} admissible under the amended contract but not '
+                    f'the original — narrowing must never widen')
+
+
+def test_annotate_changes_docs_not_admissibility(core):
+    from bigraph_schema.contract import Amendment, amend
+
+    fillers = _solver_fillers(core)
+    base = _solver_contract()
+    annotated = amend(base, Amendment(
+        op='annotate',
+        detail={'summary': 'Integrates a model with an adaptive step.',
+                'inputs': {'model': 'an SBML document'},
+                'assumptions': ['well-mixed']}))
+
+    assert annotated.face == base.face
+    assert annotated.inputs == {'model': 'an SBML document'}
+    assert annotated.assumptions == ['well-mixed']
+
+    core.register_contract('base', base)
+    core.register_contract('annotated', annotated)
+    before = core.access({'_type': 'site', '_sort': 'base'})
+    after = core.access({'_type': 'site', '_sort': 'annotated'})
+
+    for filler in fillers.values():
+        assert core.admits(before, filler) == core.admits(after, filler)
+
+
+def test_narrow_predicate_further_restricts(core):
+    """A narrowing amendment may add a predicate on top of the face."""
+    from bigraph_schema.contract import Amendment, amend
+    from bigraph_schema.assembly import collect_face
+
+    fillers = _solver_fillers(core)
+    base = _solver_contract()
+    seeded_only = amend(base, Amendment(
+        op='narrow',
+        detail={'predicate': lambda core, filler: 'seed' in collect_face(
+            core, filler)[0]},
+        why='only stochastic solvers are comparable here'))
+
+    core.register_contract('seeded_only', seeded_only)
+    site = core.access({'_type': 'site', '_sort': 'seeded_only'})
+
+    assert core.admits(site, fillers['SeededSolver'])
+    assert not core.admits(site, fillers['CopasiSolver'])
+
+
+def test_extend_is_refused(core):
+    """A contract may get stricter and better documented, never looser."""
+    from bigraph_schema.contract import Amendment, amend, AmendmentError
+
+    with pytest.raises(AmendmentError, match='never looser'):
+        amend(_solver_contract(), Amendment(
+            op='extend', detail={'inputs': {'anything': 'float'}}))
+
+
+def test_narrow_may_not_redefine_a_port(core):
+    """Replacing a port's type could widen what conforms, so it is refused —
+    that is what makes narrowing monotone by construction."""
+    from bigraph_schema.contract import Amendment, amend, AmendmentError
+
+    with pytest.raises(AmendmentError, match='may not redefine'):
+        amend(_solver_contract(), Amendment(
+            op='narrow', detail={'inputs': {'model': 'map[float]'}}))
+
+    # Restating a port identically is harmless.
+    amend(_solver_contract(), Amendment(
+        op='narrow', detail={'inputs': {'model': 'string'}}))
+
+
+def test_annotate_may_not_touch_the_typed_core(core):
+    from bigraph_schema.contract import Amendment, amend, AmendmentError
+
+    with pytest.raises(AmendmentError, match='only touch documentation'):
+        amend(_solver_contract(), Amendment(
+            op='annotate', detail={'face': {'inputs': {}}}))
+
+
+def test_contract_to_dict_is_json_safe(core):
+    """Amendments carry provenance and must survive serialization even when
+    a predicate is not itself serializable."""
+    import json
+    from bigraph_schema.contract import Amendment, amend
+
+    contract = amend(_solver_contract(), Amendment(
+        op='narrow', detail={'predicate': lambda core, filler: True},
+        by='fable', when='2026-07-30', why='stochastic only'))
+
+    payload = contract.to_dict()
+    json.dumps(payload)
+
+    assert payload['amendments'][0]['why'] == 'stochastic only'
+    assert isinstance(payload['amendments'][0]['detail']['predicate'], str)
+
+
 def test_compose_requires_one_root_per_site(core):
     """The arity law that makes splicing wrong: sites and roots match 1:1."""
     from bigraph_schema.assembly import compose, merge, barren, tensor

--- a/tests.py
+++ b/tests.py
@@ -1733,6 +1733,234 @@ def test_compose_raises_when_the_join_is_inexpressible(core):
         compose(outer, inner)
 
 
+# ── fill + admits: one primitive, one filling discipline ────────────
+
+MODEL_FACE = {
+    '_type': 'link',
+    '_inputs': {'glucose': 'float'},
+    '_outputs': {'growth_rate': 'float'}}
+
+
+def _sorted_body(core, sort, **extra):
+    """A one-site document whose site carries ``sort``."""
+    return core.access({'study': {
+        'model': dict({'_type': 'site', '_sort': sort}, **extra),
+        'note': 'string'}})
+
+
+def _process(core, inputs, outputs):
+    return core.access({
+        '_type': 'link',
+        '_inputs': inputs,
+        '_outputs': outputs})
+
+
+def test_fill_admits_a_conforming_filler(core):
+    """A face-sorted site accepts a filler whose outer face conforms."""
+    body = _sorted_body(core, MODEL_FACE)
+    filler = _process(core, {'glucose': 'float'}, {'growth_rate': 'float'})
+
+    filled = core.fill_sites(body, {'model': filler})
+
+    from bigraph_schema.assembly import interfaces
+    assert isinstance(filled['study']['model'], Link)
+    assert not isinstance(filled['study']['model'], Site)
+    assert interfaces(filled)[0]._places == ()   # the hole is closed
+
+
+def test_fill_admits_an_over_providing_filler(core):
+    """Conformance is structural subtyping: over-providing ports is fine."""
+    body = _sorted_body(core, MODEL_FACE)
+    generous = _process(
+        core,
+        {'glucose': 'float', 'oxygen': 'float'},
+        {'growth_rate': 'float', 'waste': 'float'})
+
+    filled = core.fill_sites(body, {'model': generous})
+    assert 'oxygen' in filled['study']['model']._inputs
+
+
+def test_fill_rejects_an_under_providing_filler(core):
+    """Under-providing is a fill error that names the site and the port."""
+    body = _sorted_body(core, MODEL_FACE)
+    stingy = _process(core, {'glucose': 'float'}, {'biomass': 'float'})
+
+    with pytest.raises(ValueError, match="site 'model'") as raised:
+        core.fill_sites(body, {'model': stingy})
+    assert 'growth_rate' in str(raised.value)
+
+
+def test_fill_rejects_a_shape_mismatched_port(core):
+    """A shared port whose type will not ``resolve`` is not admissible."""
+    body = _sorted_body(core, MODEL_FACE)
+    mistyped = _process(
+        core, {'glucose': 'map[float]'}, {'growth_rate': 'float'})
+
+    with pytest.raises(ValueError, match="site 'model'"):
+        core.fill_sites(body, {'model': mistyped})
+
+
+def test_fill_value_site_checks_and_rejects(core):
+    """A value-sorted site is decided by ``check``."""
+    body = _sorted_body(core, 'float')
+
+    filled = core.fill_sites(body, {'model': 3.5})
+    assert filled['study']['model'] == 3.5
+
+    with pytest.raises(ValueError, match="site 'model'"):
+        core.fill_sites(body, {'model': 'not a float'})
+
+
+def test_fill_optional_site_falls_back_to_its_default(core):
+    """``optional``/``default`` live on the site, not in a header."""
+    body = _sorted_body(core, 'float', _default=1.25)
+
+    filled = core.fill_sites(body, {})
+    assert filled['study']['model'] == 1.25
+
+    # An explicit binding still wins over the default.
+    assert core.fill_sites(body, {'model': 9.0})['study']['model'] == 9.0
+
+
+def test_fill_unsorted_site_admits_anything(core):
+    """An unsorted site is a pure Milner hole — no filling constraint."""
+    body = core.access({'world': {'hole': {'_type': 'site'}}})
+    assert core.fill_sites(body, {'hole': 42})['world']['hole'] == 42
+
+
+def test_fill_rejects_an_unknown_site_name(core):
+    body = _sorted_body(core, 'float')
+    with pytest.raises(ValueError, match='no such site'):
+        core.fill_sites(body, {'nonexistent': 1.0})
+
+
+def test_fill_rejects_an_ambiguous_site_name(core):
+    """Bindings address sites by name, so a duplicated name is an error."""
+    body = core.access({
+        'left': {'hole': {'_type': 'site'}},
+        'right': {'hole': {'_type': 'site'}}})
+    with pytest.raises(ValueError, match='ambiguous'):
+        core.fill_sites(body, {'hole': 1.0})
+
+
+def test_register_sort_overrides_the_default_discipline(core):
+    """A sort may decide admissibility for itself."""
+    core.register_sort(
+        'even', lambda core, site, filler: filler % 2 == 0)
+    body = _sorted_body(core, 'even')
+
+    assert core.fill_sites(body, {'model': 4})['study']['model'] == 4
+    with pytest.raises(ValueError, match="site 'model'"):
+        core.fill_sites(body, {'model': 3})
+
+
+def test_admits_is_not_formation(core):
+    """``admits`` (filling) and ``formation`` (nesting) are two relations.
+
+    ``admits`` is consulted at the site, *before* substitution, while the
+    site's ``_sort`` still exists; ``validate_sorting`` walks parent/child
+    pairs *after*. The distinction is load-bearing: once a site is filled
+    there is no site — and no ``_sort`` — left for ``formation`` to see.
+    """
+    from bigraph_schema.assembly import admits, interfaces, validate_sorting, Sorting
+
+    body = _sorted_body(core, MODEL_FACE)
+    (_path, site), = interfaces(body)[0]._places
+    conforming = _process(core, {'glucose': 'float'}, {'growth_rate': 'float'})
+
+    assert admits(core, site, conforming)
+    assert not admits(core, site, _process(core, {}, {}))
+
+    filled = core.fill_sites(body, {'model': conforming})
+    assert interfaces(filled)[0]._places == ()   # the sort is gone with the site
+
+    # Nesting is still policed separately, and says nothing about filling.
+    unconstrained = Sorting(sorts=set(), controls={}, formation=None)
+    assert validate_sorting(filled, unconstrained) == []
+
+
+# ── the composition law ─────────────────────────────────────────────
+
+
+def test_fill_independent_sites_commutes(core):
+    """Filling independent sites is order-independent (a monoid action)."""
+    body = core.access({'study': {
+        'model': {'_type': 'site'},
+        'reference': {'_type': 'site'}}})
+    a = _process(core, {'glucose': 'float'}, {'growth_rate': 'float'})
+    b = _process(core, {'oxygen': 'float'}, {'biomass': 'float'})
+
+    both = core.fill_sites(body, {'model': a, 'reference': b})
+    one_then_other = core.fill_sites(
+        core.fill_sites(body, {'model': a}), {'reference': b})
+    other_then_one = core.fill_sites(
+        core.fill_sites(body, {'reference': b}), {'model': a})
+
+    assert both == one_then_other == other_then_one
+
+
+def test_partially_filled_document_is_still_fillable(core):
+    """A document with sites left open is still a document (still a template)."""
+    from bigraph_schema.assembly import is_ground
+
+    body = core.access({'study': {
+        'model': {'_type': 'site'},
+        'reference': {'_type': 'site'}}})
+
+    partial = core.fill_sites(body, {'model': 1.0})
+    assert not is_ground(partial)          # still open at 'reference'
+    assert isinstance(partial['study']['reference'], Site)
+
+    ground = core.fill_sites(partial, {'reference': 2.0})
+    assert is_ground(ground)
+
+
+def test_compose_is_fill_with_positional_bindings(core):
+    """``compose`` degrades to the same substitution ``fill_sites`` performs.
+
+    Milner's sites are anonymous, so composition pairs them with roots by
+    index while ``fill_sites`` pairs them by name; on a single-site document
+    the two must agree.
+    """
+    from bigraph_schema.assembly import compose, merge, barren
+
+    outer = merge(1)
+    inner = barren('a')
+
+    assert compose(outer, inner) == core.fill_sites(outer, {'site0': inner['a']})
+
+
+def test_fill_sites_does_not_shadow_core_bind(core):
+    """``Core.bind`` binds a logical key to a target and predates this work;
+    the fill primitive must not take its name."""
+    import inspect
+
+    assert core.bind is not core.fill_sites
+    assert list(inspect.signature(core.bind).parameters) == [
+        'schema', 'state', 'raw_key', 'target']
+    assert list(inspect.signature(core.fill_sites).parameters) == [
+        'body', 'bindings']
+
+
+def test_non_ground_document_survives_round_trip(core):
+    """A template — a document that is not ground — must render and re-access."""
+    from bigraph_schema.assembly import is_ground
+
+    body = _sorted_body(core, 'float')
+    assert not is_ground(body)
+
+    # ``_sort`` is a schema field, so access resolves it to a schema node;
+    # the round-trip claim is that render → access preserves the open site
+    # *and* its sort.
+    rendered = core.render(body)
+    assert rendered['study']['model'] == {'_type': 'site', '_sort': 'float'}
+
+    round_tripped = core.access(rendered)
+    assert not is_ground(round_tripped)
+    assert isinstance(round_tripped['study']['model'], Site)
+    assert core.render(round_tripped) == rendered
+
+
 def test_compose_atom(core):
     """ion ∘ barren produces a K-atom (ion with site filled)."""
     from bigraph_schema.assembly import ion, barren, compose, interfaces, is_ground

--- a/tests.py
+++ b/tests.py
@@ -1588,6 +1588,151 @@ def test_compose_fills_sites(core):
     assert 'site1' in region
 
 
+def _resolve_wire(link_path, wire):
+    """Resolve a wire the way ``realize.port_merges`` does.
+
+    A wire is relative to the link's **parent** store, so the store it
+    designates is ``link_path[:-1] + wire``.
+    """
+    return tuple(link_path[:-1]) + tuple(wire)
+
+
+def _assert_wire_lands_on_a_store(schema, store_path):
+    """Every proper ancestor of ``store_path`` must exist in ``schema`` and
+    none of them may be a ``Link`` — ports read from stores, not from links."""
+    node = schema
+    for step in store_path[:-1]:
+        assert isinstance(node, dict) and step in node, (
+            f'wire target {store_path} escapes the composed tree at {step!r}')
+        node = node[step]
+        assert not isinstance(node, Link), (
+            f'wire target {store_path} passes through the Link at {step!r}')
+
+
+def test_compose_wires_link_into_wired_document(core):
+    """Task 0: compose a Link-bearing subtree into a site inside a wired
+    document and assert the resulting wires resolve.
+
+    The other compose tests only ever substitute *empty* regions into empty
+    holes, so the link-composition branch was unexercised. Joining an outer
+    name to an inner name has to satisfy three things at once: the wire must
+    be expressed in the **composed** tree's coordinates (not the filler's),
+    it must land on a **store** rather than inside a ``Link`` node, and the
+    filler's matching port must be wired to the **same** store — a join has
+    two ends.
+    """
+    from bigraph_schema.assembly import compose
+
+    outer = core.access({'world': {
+        'hole': {'_type': 'site'},
+        'consumer': {
+            '_type': 'link',
+            '_inputs': {'growth_rate': 'float'},
+            '_outputs': {'biomass': 'float'},
+            'outputs': {'biomass': ['biomass']}}}})
+
+    inner = core.access({'producer': {
+        'proc': {
+            '_type': 'link',
+            '_inputs': {'nutrient': 'float'},
+            '_outputs': {'growth_rate': 'float'},
+            'inputs': {'nutrient': ['nutrient']}}}})
+
+    result = compose(outer, inner)
+
+    consumer = result['world']['consumer']
+    producer = result['world']['hole']['proc']
+
+    # Both ends of the join are wired.
+    assert 'growth_rate' in consumer.inputs, 'outer input port left dangling'
+    assert 'growth_rate' in producer.outputs, 'filler output port left dangling'
+
+    # Both ends designate the same store.
+    consumer_store = _resolve_wire(
+        ('world', 'consumer'), consumer.inputs['growth_rate'])
+    producer_store = _resolve_wire(
+        ('world', 'hole', 'proc'), producer.outputs['growth_rate'])
+    assert consumer_store == producer_store, (
+        f'join ends disagree: {consumer_store} vs {producer_store}')
+
+    # And that store is reachable in the composed tree, through stores only.
+    _assert_wire_lands_on_a_store(result, consumer_store)
+
+    # The filler's already-wired port is untouched.
+    assert producer.inputs['nutrient'] == ['nutrient']
+
+
+def test_compose_wires_survive_realization(core):
+    """The wires ``compose`` writes must materialize a real shared store.
+
+    This is the end-to-end form of Task 0: realization is what turns wires
+    into stores (``realize.port_merges``), so a wire that resolves on paper
+    but not through ``realize`` is still dangling.
+    """
+    from bigraph_schema.assembly import compose
+
+    outer = core.access({'world': {
+        'hole': {'_type': 'site'},
+        'consumer': {
+            '_type': 'link',
+            'address': 'local:edge',
+            '_inputs': {'growth_rate': 'float'},
+            '_outputs': {'biomass': 'float'},
+            'outputs': {'biomass': ['biomass']}}}})
+
+    inner = core.access({'producer': {
+        'proc': {
+            '_type': 'link',
+            'address': 'local:edge',
+            '_inputs': {'nutrient': 'float'},
+            '_outputs': {'growth_rate': 'float'}}}})
+
+    result = compose(outer, inner)
+    schema, _state, _merges = core.realize({}, core.render(result))
+
+    consumer_store = _resolve_wire(
+        ('world', 'consumer'),
+        result['world']['consumer'].inputs['growth_rate'])
+
+    node = schema
+    for step in consumer_store:
+        assert isinstance(node, dict) and step in node, (
+            f'realization did not materialize {consumer_store} '
+            f'(missing {step!r})')
+        node = node[step]
+
+    # The join materialized as an actual typed store, reached from both ends.
+    assert isinstance(node, Float)
+
+
+def test_compose_raises_when_the_join_is_inexpressible(core):
+    """Wires are relative to a link's parent and cannot ascend, so a join is
+    only expressible when the outer link's parent contains the filled site.
+    When it does not, ``compose`` must say so rather than emit a wire that
+    silently resolves to nothing."""
+    from bigraph_schema.assembly import compose
+
+    # The consumer sits in a sibling subtree of the site, so no relative
+    # wire from ``left/`` can reach a store under ``right/hole/``.
+    outer = core.access({
+        'left': {
+            'consumer': {
+                '_type': 'link',
+                '_inputs': {'growth_rate': 'float'},
+                '_outputs': {}}},
+        'right': {
+            'hole': {'_type': 'site'}}})
+
+    inner = core.access({'producer': {
+        'proc': {
+            '_type': 'link',
+            '_inputs': {},
+            '_outputs': {'growth_rate': 'float'}}}})
+
+    with pytest.raises(ValueError, match='growth_rate'):
+        compose(outer, inner)
+
+
 def test_compose_atom(core):
     """ion ∘ barren produces a K-atom (ion with site filled)."""
     from bigraph_schema.assembly import ion, barren, compose, interfaces, is_ground

--- a/tests.py
+++ b/tests.py
@@ -2333,6 +2333,149 @@ def test_fill_does_not_splice_a_multi_root_filler(core):
     assert filled['study']['level'] is not filled['study']['model']['level']
 
 
+# ── address injection: an abstract process ──────────────────────────
+
+
+SOLVER_FACE = {
+    '_type': 'link',
+    '_inputs': {'model': 'string'},
+    '_outputs': {'trajectory': 'map[float]'}}
+
+
+class CopasiSolver(Edge):
+    """A conforming implementation of the solver face."""
+
+    def inputs(self):
+        return {'model': 'string'}
+
+    def outputs(self):
+        return {'trajectory': 'map[float]'}
+
+
+class TelluriumSolver(Edge):
+    """A second conforming implementation — the point of the pattern."""
+
+    def inputs(self):
+        return {'model': 'string', 'seed': 'integer'}   # may over-provide
+
+    def outputs(self):
+        return {'trajectory': 'map[float]'}
+
+
+class NotASolver(Edge):
+    """Right shape of thing, wrong face."""
+
+    def inputs(self):
+        return {'model': 'string'}
+
+    def outputs(self):
+        return {'steady_state': 'float'}
+
+
+def _abstract_solver(core):
+    """A template edge whose face, config and wiring are fixed and whose
+    **address** — its implementation — is the only hole."""
+    core.register_link('CopasiSolver', CopasiSolver)
+    core.register_link('TelluriumSolver', TelluriumSolver)
+    core.register_link('NotASolver', NotASolver)
+    return core.access({
+        'sim': {
+            '_type': 'link',
+            'address': {'_type': 'site', '_sort': SOLVER_FACE},
+            '_inputs': {'model': 'string'},
+            '_outputs': {'trajectory': 'map[float]'},
+            'inputs': {'model': ['model']},
+            'outputs': {'trajectory': ['traj']}},
+        'model': 'string'})
+
+
+def test_an_address_site_is_an_open_hole(core):
+    """An edge that fixes its face but leaves ``address`` open is a process
+    definition without an implementation — and it is genuinely not ground."""
+    from bigraph_schema.assembly import is_ground, collect_sites
+
+    template = _abstract_solver(core)
+
+    assert not is_ground(template)
+    assert 'sim/address' in collect_sites(template)
+
+
+@pytest.mark.parametrize('implementation', ['CopasiSolver', 'TelluriumSolver'])
+def test_injecting_a_conforming_address_builds(core, implementation):
+    """Inject a conforming implementation → a runnable edge. This is the
+    solver-swap pattern: one face, many implementations, no code."""
+    template = _abstract_solver(core)
+
+    schema, state = core.build(
+        template, {'sim/address': f'local:{implementation}'})
+
+    assert state['sim']['address'] == {
+        'protocol': 'local', 'data': implementation}
+    assert isinstance(state['sim']['instance'], Edge)
+    # The parts the template fixed are untouched by the injection.
+    assert state['sim']['inputs'] == {'model': ['model']}
+    assert state['sim']['outputs'] == {'trajectory': ['traj']}
+
+
+def test_injecting_a_non_conforming_address_names_the_mismatch(core):
+    template = _abstract_solver(core)
+
+    with pytest.raises(ValueError, match="site 'sim/address'") as raised:
+        core.build(template, {'sim/address': 'local:NotASolver'})
+
+    message = str(raised.value)
+    assert 'trajectory' in message          # the port the face required
+    assert 'steady_state' in message        # what the filler offered instead
+
+
+def test_both_injection_flavors_go_through_one_fill(core):
+    """Address-hole and whole-edge site are the same operation: one
+    ``fill``, one ``admits``, differing only in what the filler spells."""
+    from bigraph_schema.assembly import interfaces
+    core.register_link('CopasiSolver', CopasiSolver)
+
+    # (a) address-hole — only the implementation varies.
+    address_hole = _abstract_solver(core)
+    by_address = core.fill_sites(
+        address_hole, {'sim/address': 'local:CopasiSolver'})
+
+    # (b) whole-edge site — inject the entire edge.
+    edge_hole = core.access({
+        'sim': {'_type': 'site', '_sort': SOLVER_FACE},
+        'model': 'string'})
+    by_edge = core.fill_sites(edge_hole, {'sim': core.access({
+        '_type': 'link',
+        'address': 'local:CopasiSolver',
+        'inputs': {'model': ['model']},
+        'outputs': {'trajectory': ['traj']}})})
+
+    for filled in (by_address, by_edge):
+        assert interfaces(filled)[0]._places == ()
+        assert filled['sim'].address._default == {
+            'protocol': 'local', 'data': 'CopasiSolver'}
+
+
+def test_wired_link_defaults_and_realizes(core):
+    """A link that declared its wiring must still default and realize.
+
+    ``access`` materializes declared wires as a plain ``{port: path}`` dict;
+    ``default``/``realize`` used to walk that as a schema and reach a raw
+    path list, so any edge that named its own wiring could not be built.
+    """
+    wired = core.access({'p': {
+        '_type': 'link',
+        '_inputs': {'x': 'float'},
+        '_outputs': {'y': 'float'},
+        'inputs': {'x': ['x']},
+        'outputs': {'y': ['y']}}})
+
+    state = core.fill(wired, {})
+
+    assert state['p']['inputs'] == {'x': ['x']}
+    assert state['p']['outputs'] == {'y': ['y']}
+    assert isinstance(state['p']['instance'], Edge)
+
+
 def test_compose_requires_one_root_per_site(core):
     """The arity law that makes splicing wrong: sites and roots match 1:1."""
     from bigraph_schema.assembly import compose, merge, barren, tensor

--- a/tests.py
+++ b/tests.py
@@ -2243,6 +2243,104 @@ def test_link_round_trips_through_render(core, declaration):
         assert 'address' not in (rendered if isinstance(rendered, dict) else {})
 
 
+class LevelProcess(Edge):
+    """A registered edge that declares its ports on the class, the way every
+    real process does — the declaration names an address, not an interface."""
+
+    def inputs(self):
+        return {'level': 'float'}
+
+    def outputs(self):
+        return {'level': 'float'}
+
+
+def test_admits_resolves_a_filler_face_from_its_address(core):
+    """A real process declaration carries an address and a config, not its
+    ports. ``admits`` must resolve the face from the registered class, or a
+    site could only ever be filled by a declaration restating its own
+    interface — which no registered process does."""
+    core.register_link('LevelProcess', LevelProcess)
+
+    template = core.access({'study': {'model': {
+        '_type': 'site',
+        '_sort': {'_type': 'link',
+                  '_inputs': {'level': 'float'},
+                  '_outputs': {'level': 'float'}}}}})
+
+    # No _inputs/_outputs declared anywhere — only the address.
+    filler = core.access({'_type': 'link', 'address': 'local:LevelProcess'})
+    assert filler._inputs == {}
+
+    filled = core.fill_sites(template, {'model': filler})
+    assert filled['study']['model'] is not None
+
+    # An address naming a class with the wrong face is still rejected.
+    core.register_link('EmptyProcess', Edge)
+    wrong = core.access({'_type': 'link', 'address': 'local:EmptyProcess'})
+    with pytest.raises(ValueError, match="site 'model'"):
+        core.fill_sites(template, {'model': wrong})
+
+
+# ── place semantics: a site takes one root, at the site's position ──
+
+
+def test_fill_places_a_filler_at_the_site_position(core):
+    """One site, one filler, at the site's own path.
+
+    Evidence (recorded here because it settles the open question): handed a
+    template whose ``model`` site is filled by a real registered process,
+    ``process_bigraph.Composite`` reports
+    ``process_paths == [('study', 'model')]`` — it expects the process node
+    to sit exactly where the site was.
+    """
+    core.register_link('LevelProcess', LevelProcess)
+    template = core.access({'study': {
+        'model': {'_type': 'site'},
+        'level': 'float'}})
+    filler = core.access({'_type': 'link', 'address': 'local:LevelProcess'})
+
+    filled = core.fill_sites(template, {'model': filler})
+
+    assert isinstance(filled['study']['model'], Link)
+    assert sorted(filled['study']) == ['level', 'model']
+
+
+def test_fill_does_not_splice_a_multi_root_filler(core):
+    """A multi-root filler nests **under** the site; it is not spliced into
+    the site's parent.
+
+    Splicing would (a) drop the site's key, so the filled region loses the
+    name the template gave it, and (b) merge the filler's roots into the
+    parent's namespace — here the filler's own ``level`` store would collide
+    with the template's ``study/level`` and one of the two would be silently
+    lost. Milner is the same answer from the other side: composition plugs
+    **one root into one site**, so a filler with n roots fills n sites, not
+    one — ``compose`` already enforces that arity.
+    """
+    template = core.access({'study': {
+        'model': {'_type': 'site'},
+        'level': 'float'}})
+    multi = core.access({
+        'A': {'_type': 'link', 'address': 'local:edge'},
+        'B': {'_type': 'link', 'address': 'local:edge'},
+        'level': 'float'})
+
+    filled = core.fill_sites(template, {'model': multi})
+
+    assert sorted(filled['study']) == ['level', 'model']
+    assert sorted(filled['study']['model']) == ['A', 'B', 'level']
+    # The filler's store and the template's store stay distinct.
+    assert filled['study']['level'] is not filled['study']['model']['level']
+
+
+def test_compose_requires_one_root_per_site(core):
+    """The arity law that makes splicing wrong: sites and roots match 1:1."""
+    from bigraph_schema.assembly import compose, merge, barren, tensor
+
+    with pytest.raises(ValueError, match='faces must match'):
+        compose(merge(1), tensor(barren('a'), barren('b')))
+
+
 def test_rendered_link_realizes(core):
     """A rendered link must survive realization — the round trip is only
     useful if the far end still loads. An address-less link previously

--- a/tests.py
+++ b/tests.py
@@ -2165,13 +2165,9 @@ def test_build_of_a_ground_document_is_the_identity_on_shape(core):
     assert state == {'cell': {'mass': 0.0}}
 
 
-@pytest.mark.xfail(
-    reason='pre-existing on origin/main: core.access leaves a Link.address '
-           'as a raw str/dict rather than a Protocol, so default/realize '
-           'walk it as a schema and fail. Blocks build() for any filler '
-           'declaring an explicit address.',
-    strict=True)
 def test_build_with_an_addressed_filler(core):
+    """The real case: a filler that names an address — every registered
+    process does — builds to a runnable document with a live instance."""
     template = core.access({'study': {
         'model': {'_type': 'site', '_sort': MODEL_FACE}}})
     addressed = core.access({
@@ -2180,7 +2176,87 @@ def test_build_with_an_addressed_filler(core):
         '_inputs': {'glucose': 'float'},
         '_outputs': {'growth_rate': 'float'}})
 
-    core.build(template, {'model': addressed})
+    schema, state = core.build(template, {'model': addressed})
+
+    assert schema['study']['model'].address._default == {
+        'protocol': 'local', 'data': 'edge'}
+    assert state['study']['model']['address'] == {
+        'protocol': 'local', 'data': 'edge'}
+    assert isinstance(state['study']['model']['instance'], Edge)
+
+
+# ── addresses are values, not type expressions ──────────────────────
+
+
+@pytest.mark.parametrize('address', [
+    'local:edge', 'edge', {'protocol': 'local', 'data': 'edge'}])
+def test_access_compiles_an_address_to_a_protocol(core, address):
+    """Every spelling of an address compiles to the same ``Protocol``.
+
+    ``'local:edge'`` must not be routed through the type parser — it parses
+    under the named-parameter grammar and yields ``{'local': 'edge'}``,
+    which no consumer can read.
+    """
+    from bigraph_schema.schema import Protocol
+
+    link = core.access({
+        '_type': 'link',
+        'address': address,
+        '_inputs': {'x': 'float'},
+        '_outputs': {'y': 'float'}})
+
+    assert isinstance(link.address, Protocol)
+    assert link.address._default == {'protocol': 'local', 'data': 'edge'}
+
+
+def test_access_and_realize_agree_on_an_address(core):
+    """``access`` and ``realize`` must compile the same link identically —
+    they are two doors onto one document."""
+    declaration = {
+        '_type': 'link', 'address': 'local:edge',
+        '_inputs': {'x': 'float'}, '_outputs': {'y': 'float'}}
+
+    accessed = core.access(declaration)
+    realized_schema, _state, _merges = core.realize({}, {'p': declaration})
+
+    assert accessed.address._default == realized_schema['p'].address._default
+
+
+@pytest.mark.parametrize('declaration', [
+    {'_type': 'link', 'address': 'local:edge',
+     '_inputs': {'x': 'float'}, '_outputs': {'y': 'float'}},
+    {'_type': 'link',
+     '_inputs': {'x': 'float'}, '_outputs': {'y': 'float'}},
+    {'_type': 'link', 'address': 'local:edge', 'inputs': {'x': ['store']},
+     '_inputs': {'x': 'float'}, '_outputs': {'y': 'float'}},
+])
+def test_link_round_trips_through_render(core, declaration):
+    """``render`` is the inverse of ``access``: an address survives, and a
+    link that never declared one does not acquire a stand-in."""
+    accessed = core.access(declaration)
+    rendered = core.render(accessed)
+
+    assert core.access(rendered) == accessed
+    if 'address' in declaration:
+        assert rendered['address'] == 'local:edge'
+    else:
+        assert 'address' not in (rendered if isinstance(rendered, dict) else {})
+
+
+def test_rendered_link_realizes(core):
+    """A rendered link must survive realization — the round trip is only
+    useful if the far end still loads. An address-less link previously
+    rendered a bare ``protocol`` schema that ``load_protocol`` rejected."""
+    accessed = core.access({'p': {
+        '_type': 'link',
+        '_inputs': {'x': 'float'},
+        '_outputs': {'y': 'float'},
+        'inputs': {'x': ['x']}}})
+
+    schema, state, _merges = core.realize({}, core.render(accessed))
+
+    assert isinstance(state['p']['instance'], Edge)
+    assert 'x' in schema
 
 
 def test_compose_atom(core):


### PR DESCRIPTION
Implements Layer 1 of framework-unification (spec PR #174), built by Fable after its architecture review. **The blocking Task 0 revealed the foundation was actually broken** — the untested `compose` link-branch had three independent bugs, all masked because every prior compose test substituted *empty regions into empty holes*.

## Task 0 — `compose` link-branch was wrong three ways (now fixed + tested)
Composing a `Link`-bearing subtree into a site in a *wired* document exposed:
1. the wire was never rebased — written in the filler's coordinates, so realization **crashed** (`NotFoundLookupError`);
2. it pointed *inside* a `Link` node, not at a store;
3. only one end was wired (the filler's matching output port dangled).

**Fix (`1a1c139`):** joining an outer name to an inner name now wires *both* ports to one shared store (the filler link's default output store), rebasing the filler's path through the site it was substituted into. Verified against `realize.port_merges` that wires are relative to a link's parent and cannot ascend; `compose` now **raises naming the port** when the join isn't expressible, instead of emitting a silently-dangling wire. 3 regression tests incl. an end-to-end one asserting the join materializes a single typed `Float` store through `realize`.

## The `fill` primitive (`9e1b18d`)
```
assembly.fill_sites(core, body, bindings)      # THE primitive (substitution + admits)
assembly.admits(core, site, filler) / admits_why / face_conforms / collect_face / collect_sites
assembly.compose(outer, inner, core=None)      # positional fill + join; shares one substitution
core.register_sort / core.admits / core.fill_sites
```
Deletions held per the review: **no `compose_at`, no `Slot`/`Template` type, no `_slots` header, nothing added to `BASE_TYPES`.** `admits` (filling) is kept distinct from `Sorting.formation` (nesting). Also fixed `render` dropping a site's `_sort` (leaked a Python object into the JSON document) so face-sorted templates round-trip to YAML/JSON.

## Tests
Baseline **1067 → 1086 passed, 0 failures** (`tests.py` + `test_matrix.py`). +19 tests (3 Task-0, 11 fill/admits, 4 composition-law incl. `Core.bind` non-shadowing, 1 round-trip).

## Decisions flagged for review (see PR discussion)
- **`instantiate` vs `compose` place semantics** — `instantiate` forest-splices a multi-root filler at the parent (Milner: roots are regions); `compose`'s `_set_at_path` keeps the site key as a wrapper node. `fill_sites` follows `compose` (conservative, no behavior change). Needs a decision before Layer 2a fills real composites.
- **`is_bound`/`find_unbound_links`** read wires absolute-from-root, contradicting `port_merges`' relative-to-parent — orthogonal, untested, left alone.

Deferred (TODO, not built): the cardinality `ReactionRule` and the `build()` template convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)