### PR TITLE
release: bigraph-schema 1.4.4 (publish Layer 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigraph-schema"
-version = "1.4.3"
+version = "1.4.4"
 description = "A serializable type schema for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump 1.4.3 → 1.4.4. 1.4.3 was already on PyPI from a pre-Layer-1 commit, and Layer 1 (#175) merged without a version bump — so main's 1.4.3 (with `fill_sites`/`collect_sites`) collides with the published 1.4.3 (without). Bumping to 1.4.4 lets Layer 1 publish and downstreams pin `>=1.4.4`. Tag `v1.4.4` after merge triggers the trusted-publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)