### PR TITLE
perf: lazy process discovery (cold allocate_core ~7x, no eager heavy imports)

### DIFF
--- a/bigraph_schema/core.py
+++ b/bigraph_schema/core.py
@@ -234,6 +234,31 @@ class Core:
         for key, link in links.items():
             self.register_link(key, link)
 
+    def list_processes(self):
+        """Return every known link NAME without importing anything.
+
+        Works whether ``link_registry`` is a plain dict (eager discovery) or a
+        LazyLinkRegistry (lazy discovery) — in the lazy case this enumerates
+        pending placeholders too, so "list every available process" callers see
+        the full set without triggering heavy imports. Use ``materialize_links``
+        (or iterate ``link_registry.items()``) when the actual classes are
+        needed.
+        """
+        return list(self.link_registry.keys())
+
+    def materialize_links(self):
+        """Force lazy discovery to import every pending process module.
+
+        No-op for an eager/plain-dict registry. After this call
+        ``link_registry`` holds real classes for every known name — the
+        explicit "eager" escape hatch for callers that must introspect every
+        registered class.
+        """
+        materialize = getattr(self.link_registry, "materialize_all", None)
+        if callable(materialize):
+            materialize()
+        return self
+
     def update_link(self, key, data):
         """Deep-merge metadata/overrides into an existing registry entry."""
         self.link_registry[key] = data
@@ -1574,6 +1599,7 @@ class Core:
 
 
 _cached_base_core = None
+_cached_base_core_eager = None
 
 
 def _isolated_copy(base):
@@ -1594,7 +1620,12 @@ def _isolated_copy(base):
     import copy
     clone = copy.copy(base)
     clone.registry = dict(base.registry)
-    clone.link_registry = dict(base.link_registry)
+    # ``link_registry`` may be a LazyLinkRegistry: use its ``.copy()`` so
+    # placeholders are preserved instead of being materialized (a plain
+    # ``dict(...)`` would import every pending module). Falls back to ``dict``
+    # for the eager/plain-dict case.
+    _copy = getattr(base.link_registry, "copy", None)
+    clone.link_registry = _copy() if callable(_copy) else dict(base.link_registry)
     clone.method_registry = dict(base.method_registry)
     # Fresh, empty per-instance caches so warm entries (and the id-keyed
     # witnesses they hold) never bleed between independently-allocated cores.
@@ -1608,7 +1639,7 @@ def _isolated_copy(base):
     return clone
 
 
-def allocate_core(top=None):
+def allocate_core(top=None, eager=None):
     """Allocate a new Core with all discovered packages.
 
     The base core (without ``top``) is built once and cached to avoid
@@ -1617,16 +1648,30 @@ def allocate_core(top=None):
     types/links/methods registered on one core never leak into another,
     while the base types from discovery are present on every copy. See
     :func:`_isolated_copy` for the (container-level) copy semantics.
+
+    Discovery is LAZY by default: process modules are imported only when a
+    process address is first resolved, so a cold ``allocate_core()`` no longer
+    imports every (possibly heavy) package up front. ``core.link_registry``
+    still enumerates every known process NAME without importing. Pass
+    ``eager=True`` to force the classic behaviour of importing everything and
+    populating a plain-dict registry (also toggled by
+    ``BIGRAPH_SCHEMA_LAZY_DISCOVERY=0``). The lazy and eager base cores are
+    cached separately.
     """
-    global _cached_base_core
-    if top is None and _cached_base_core is not None:
-        return _isolated_copy(_cached_base_core)
+    global _cached_base_core, _cached_base_core_eager
+    if top is None:
+        cached = _cached_base_core_eager if eager else _cached_base_core
+        if cached is not None:
+            return _isolated_copy(cached)
 
     core = Core(BASE_TYPES)
-    core = discover_packages(core, top)
+    core = discover_packages(core, top, eager=eager)
 
     if top is None:
-        _cached_base_core = core
+        if eager:
+            _cached_base_core_eager = core
+        else:
+            _cached_base_core = core
         return _isolated_copy(core)
 
     return core

--- a/bigraph_schema/package/discover.py
+++ b/bigraph_schema/package/discover.py
@@ -1,7 +1,13 @@
 import importlib
 import importlib.metadata
+import importlib.util
 import pkgutil
 import inspect
+import os
+import sys
+import json
+import hashlib
+import tempfile
 from typing import Dict, List, Tuple, Set, Type
 
 from bigraph_schema import Edge
@@ -225,18 +231,338 @@ def load_local_modules(core, top=None) -> tuple[
     return core, edges, types
 
 
-def discover_packages(core, top=None):
-    core, edges, types = load_local_modules(core, top=top)
+def _eager_register(core, edges, types):
+    """Register discovered edges/types into ``core`` (the classic eager path).
+
+    Returns ``(edge_index, type_modules)`` describing exactly what was
+    registered, so the lazy path can replay it later without importing:
+
+    * ``edge_index`` — ``registry_key -> defining_module`` for every link key
+      eager registration created (fully-qualified names, plus short-name
+      aliases under the same first-wins rule).
+    * ``type_modules`` — ordered, de-duplicated list of modules that must be
+      imported to reproduce type state (modules that defined a discovered
+      ``Node`` type, followed by modules exposing a ``register_types`` hook).
+    """
+    edge_index = {}
+    # Seed "claimed" short names with whatever is already registered (e.g. the
+    # base ``edge`` link) so the short-alias first-wins rule matches eager.
+    claimed = set(core.link_registry.keys())
 
     for fq_name, edge_cls in edges:
         core.register_link(fq_name, edge_cls)
+        module = edge_cls.__module__
+        edge_index[fq_name] = module
 
         short = fq_name.split(".")[-1]
-        if short not in core.link_registry:
+        if short not in claimed:
             core.register_link(short, edge_cls)
+            claimed.add(short)
+            edge_index[short] = module
+        claimed.add(fq_name)
+
+    type_modules = []
+    seen_type_modules = set()
 
     for fq_name, type_cls in types:
         short = fq_name.split(".")[-1]
         core.register_type(short, type_cls)
+        module = type_cls.__module__
+        if module not in seen_type_modules:
+            seen_type_modules.add(module)
+            type_modules.append(module)
 
+    # Modules exposing a ``register_types`` hook must be re-imported by the
+    # lazy path so those (dict-based) types are registered too. Capture them in
+    # import order (sys.modules is insertion-ordered), but ONLY for the
+    # process-library import packages we actually walked — scanning every dist
+    # would false-positive on unrelated ``register_types`` attributes (e.g.
+    # torch's ``_OpNamespace``). We also require the hook to be a real function
+    # defined in that module, not an arbitrary attribute of that name.
+    prefixes = sorted({pkg for _dist, pkg in _process_lib_packages(core)})
+    dotted = tuple(p + "." for p in prefixes)
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None:
+            continue
+        if mod_name not in prefixes and not mod_name.startswith(dotted):
+            continue
+        if mod_name in seen_type_modules:
+            continue
+        if _has_register_types_hook(mod, mod_name):
+            seen_type_modules.add(mod_name)
+            type_modules.append(mod_name)
+
+    return edge_index, type_modules
+
+
+def _has_register_types_hook(module, module_name):
+    """True only for a genuine ``register_types`` hook defined in ``module``."""
+    hook = getattr(module, "register_types", None)
+    if not callable(hook):
+        return False
+    # Must be a plain function (not a class/namespace object) and, when it
+    # exposes a ``__module__``, actually belong to this module — this filters
+    # out re-exported or foreign callables of the same name.
+    hook_module = getattr(hook, "__module__", None)
+    return hook_module is None or hook_module == module_name
+
+
+def _apply_type_modules(core, type_modules):
+    """Re-import ``type_modules`` and replay their type registration.
+
+    Reproduces eager ordering EXACTLY. Eager runs every ``register_types``
+    hook during the package walk (before any ``Node`` types are registered),
+    then registers all discovered ``Node`` subclasses afterwards. So we do the
+    same in two passes over ``type_modules`` (which is ordered as the eager
+    walk produced): pass 1 imports each module and runs its hook; pass 2
+    registers each module's ``Node`` types.
+    """
+    imported = []
+    for module_name in type_modules:
+        try:
+            module = importlib.import_module(module_name)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"lazy discovery: skipping type module `{module_name}` "
+                f"({type(exc).__name__} raised at import: {exc})")
+            continue
+        imported.append((module_name, module))
+
+    # Pass 1: register_types hooks, in order.
+    for module_name, module in imported:
+        if _has_register_types_hook(module, module_name):
+            core = module.register_types(core)
+
+    # Pass 2: Node subclasses, in order.
+    for module_name, module in imported:
+        for fq_name, type_cls in find_types(
+                inspect.getmembers(module, inspect.isclass),
+                module_name=module_name):
+            core.register_type(fq_name.split(".")[-1], type_cls)
     return core
+
+
+def _apply_lazy_index(core, index):
+    """Install a :class:`LazyLinkRegistry` from a discovery ``index`` dict.
+
+    ``index`` is ``{"edges": {key: module}, "type_modules": [...]}``. Types are
+    registered eagerly (they cannot be triggered by address resolution), but
+    only the lightweight type-bearing modules get imported — heavy edge-only
+    distributions (torch, vEcoli, ...) are deferred until a process address is
+    actually resolved.
+    """
+    from bigraph_schema.package.lazy_registry import LazyLinkRegistry
+
+    core = _apply_type_modules(core, index.get("type_modules", []))
+    core.link_registry = LazyLinkRegistry(
+        resolved=dict(core.link_registry),
+        index=index.get("edges", {}))
+    return core
+
+
+def discover_packages(core, top=None, eager=None):
+    """Discover and register every bigraph-schema process package.
+
+    By default (``eager=None``) discovery is LAZY: a cheap ``name -> module``
+    index is built (or loaded from an on-disk cache keyed by installed-dist
+    versions), process modules are imported only when their address is first
+    resolved, and ``core.link_registry`` becomes a
+    :class:`~bigraph_schema.package.lazy_registry.LazyLinkRegistry` that still
+    enumerates every known name without importing.
+
+    Pass ``eager=True`` (or set ``BIGRAPH_SCHEMA_LAZY_DISCOVERY=0``) to force
+    the classic behaviour: import every submodule of every package up front and
+    populate a plain-dict ``link_registry``. ``top`` (explicit class dicts) is
+    always handled eagerly.
+    """
+    if eager is None:
+        eager = os.environ.get("BIGRAPH_SCHEMA_LAZY_DISCOVERY", "1") == "0"
+
+    # Explicit ``top`` classes and forced-eager both take the classic path.
+    if eager or top is not None:
+        core, edges, types = load_local_modules(core, top=top)
+        _eager_register(core, edges, types)
+        return core
+
+    index = _load_or_build_index(core)
+    if index is None:
+        # Building failed for some reason — fall back to eager so discovery
+        # never silently returns an empty registry.
+        core, edges, types = load_local_modules(core, top=None)
+        _eager_register(core, edges, types)
+        return core
+
+    return _apply_lazy_index(core, index)
+
+
+# ---------------------------------------------------------------------------
+# Discovery-index cache (keyed by installed-dist versions + source mtimes)
+# ---------------------------------------------------------------------------
+#
+# The lazy path needs a correct name -> module index. Rather than guess it from
+# a fragile static (AST) scan, we derive it from a REAL eager discovery the
+# first time — which is exactly correct (names, short-alias winners, ordering,
+# and edge-vs-type classification) — and memoize the result to disk keyed by
+# the installed process-lib distributions. Subsequent cold starts (every
+# subprocess-isolated run, every Ray worker) read the cache and skip importing
+# heavy edge-only packages entirely.
+
+_CACHE_VERSION = 1
+
+
+def _process_lib_packages(core):
+    """(dist_name, import_package) pairs for every process-library dist."""
+    pairs = []
+    for dist_name, packages in core.distributions_packages.items():
+        try:
+            dist = importlib.metadata.distribution(dist_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+        if not is_process_library(dist):
+            continue
+        for pkg in packages:
+            pairs.append((dist_name, pkg))
+    return sorted(set(pairs))
+
+
+def _package_source_signature(pkg):
+    """Cheap content signature of a top-level import package WITHOUT importing.
+
+    Uses ``find_spec`` (which locates but does not execute a top-level package)
+    and hashes the (relative path, mtime, size) of every ``*.py`` beneath it,
+    so editable-install source edits invalidate the cache. Never imports the
+    package's code, so no heavy dependency is pulled in here.
+    """
+    try:
+        spec = importlib.util.find_spec(pkg)
+    except (ImportError, AttributeError, ValueError):
+        return f"{pkg}:nospec"
+    if spec is None:
+        return f"{pkg}:nospec"
+
+    roots = list(getattr(spec, "submodule_search_locations", None) or [])
+    if not roots and spec.origin and spec.origin != "namespace":
+        roots = [os.path.dirname(spec.origin)]
+
+    parts = []
+    for root in roots:
+        if not root or not os.path.isdir(root):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                fp = os.path.join(dirpath, fn)
+                try:
+                    st = os.stat(fp)
+                except OSError:
+                    continue
+                rel = os.path.relpath(fp, root)
+                parts.append(f"{rel}:{int(st.st_mtime_ns)}:{st.st_size}")
+    parts.sort()
+    return f"{pkg}:" + hashlib.sha1("|".join(parts).encode()).hexdigest()
+
+
+def _installed_signature(core):
+    """A hash string identifying the installed process-lib set + its source."""
+    tokens = [f"cachev={_CACHE_VERSION}", f"py={sys.version_info[:2]}"]
+    for dist_name, pkg in _process_lib_packages(core):
+        try:
+            version = importlib.metadata.version(dist_name)
+        except importlib.metadata.PackageNotFoundError:
+            version = "?"
+        tokens.append(f"{dist_name}=={version}")
+        tokens.append(_package_source_signature(pkg))
+    return hashlib.sha1("\n".join(tokens).encode()).hexdigest()
+
+
+def _cache_dir():
+    base = os.environ.get("BIGRAPH_SCHEMA_CACHE_DIR")
+    if not base:
+        base = os.path.join(
+            os.path.expanduser("~"), ".cache", "bigraph-schema", "discovery")
+    return base
+
+
+def _cache_path(signature):
+    return os.path.join(_cache_dir(), f"index-{signature}.json")
+
+
+def _read_cache(signature):
+    path = _cache_path(signature)
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("signature") != signature:
+        return None
+    if "edges" not in data or "type_modules" not in data:
+        return None
+    return data
+
+
+def _write_cache(signature, index):
+    path = _cache_path(signature)
+    payload = dict(index)
+    payload["signature"] = signature
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # Atomic write so concurrent workers never read a half-written file.
+        fd, tmp = tempfile.mkstemp(
+            dir=os.path.dirname(path), prefix="index-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+    except OSError:
+        # A read-only or unwritable cache dir must never break discovery.
+        pass
+
+
+def _build_index(core):
+    """Run a real eager discovery on a throwaway core and capture the index.
+
+    The passed ``core`` is not mutated: discovery runs on a fresh ``Core`` so
+    building the cache has no side effects on the caller's registries.
+    """
+    from bigraph_schema.core import Core, BASE_TYPES
+
+    probe = Core(BASE_TYPES)
+    probe, edges, types = load_local_modules(probe, top=None)
+    edge_index, type_modules = _eager_register(probe, edges, types)
+    return {"edges": edge_index, "type_modules": type_modules}
+
+
+def _load_or_build_index(core):
+    """Return the discovery index, from disk cache or by building (+caching)."""
+    if os.environ.get("BIGRAPH_SCHEMA_DISCOVERY_CACHE", "1") == "0":
+        # Cache disabled: build fresh every time (still lazy at resolution).
+        try:
+            return _build_index(core)
+        except Exception:  # noqa: BLE001
+            return None
+
+    try:
+        signature = _installed_signature(core)
+    except Exception:  # noqa: BLE001
+        signature = None
+
+    if signature is not None:
+        cached = _read_cache(signature)
+        if cached is not None:
+            return cached
+
+    try:
+        index = _build_index(core)
+    except Exception:  # noqa: BLE001
+        return None
+
+    if signature is not None:
+        _write_cache(signature, index)
+    return index

--- a/bigraph_schema/package/lazy_registry.py
+++ b/bigraph_schema/package/lazy_registry.py
@@ -1,0 +1,212 @@
+"""
+==================
+Lazy link registry
+==================
+
+A ``dict``-compatible mapping that stands in for ``core.link_registry`` and
+makes *process discovery* lazy.
+
+Eager discovery (``recursive_dynamic_import``) imports EVERY submodule of EVERY
+bigraph-schema-dependent distribution at ``allocate_core()`` time — including
+heavy ones (torch, vEcoli, copasi, ...) even when a composite only instantiates
+two processes. That import walk dominates cold start.
+
+``LazyLinkRegistry`` splits the registry into two parts:
+
+* ``_resolved`` — ``name -> class`` for links that are actually imported.
+* ``_index``    — ``name -> module`` placeholders for links that are *known*
+                  (their name and defining module were recorded by a prior real
+                  discovery) but **not yet imported**.
+
+Enumeration of NAMES (``keys``/``__iter__``/``__contains__``/``len``) consults
+both halves and imports nothing, so callers that list "every available process"
+(workbench Registry tab, ``vivarium-interface`` validation, ``/list-processes``)
+keep working. Fetching a CLASS (``__getitem__``/``get``) imports just that one
+module on first use; iterating VALUES (``items``/``values``/``dict(reg)``)
+transparently materializes everything, so class-consuming callers stay correct
+(they simply pay the import cost, which is exactly the "list them all" case).
+
+The mapping is intentionally standalone (no ``core`` reference): materializing a
+placeholder only needs to import the module and pick out its ``Edge`` classes,
+so a ``LazyLinkRegistry`` can be cheaply ``.copy()``-ed per ``allocate_core()``
+without materializing anything.
+"""
+
+import importlib
+import inspect
+
+from bigraph_schema import Edge
+
+
+def _module_edge_classes(module_name):
+    """Return ``{class_name: class}`` for Edge subclasses DEFINED in ``module_name``.
+
+    Only classes whose ``__module__`` equals ``module_name`` are returned, so a
+    process merely imported into the module (and owned by another module) is not
+    re-registered here — it is handled when its own module materializes. This
+    mirrors the fully-qualified-name keying used by eager discovery.
+    """
+    module = importlib.import_module(module_name)
+    found = {}
+    for _name, cls in inspect.getmembers(module, inspect.isclass):
+        if not issubclass(cls, Edge) or cls is Edge:
+            continue
+        if cls.__module__ != module_name:
+            continue
+        found[cls.__name__] = cls
+    return found
+
+
+class LazyLinkRegistry:
+    """A ``dict``-like link registry with lazy per-module import.
+
+    Parameters
+    ----------
+    resolved : dict | None
+        Already-imported ``name -> class`` entries (e.g. the base ``edge``
+        link, or anything registered explicitly before discovery).
+    index : dict | None
+        Placeholder ``name -> module`` entries: a name that can be resolved by
+        importing ``module`` and picking out the matching Edge class.
+    """
+
+    def __init__(self, resolved=None, index=None):
+        self._resolved = dict(resolved or {})
+        self._index = dict(index or {})
+        # A placeholder that is superseded by an explicit set/registration must
+        # never be resurrected from the index, so setitem always pops the index.
+
+    # -- materialization ---------------------------------------------------
+
+    def _materialize_module(self, module_name):
+        """Import ``module_name`` and promote every placeholder it backs."""
+        try:
+            classes = _module_edge_classes(module_name)
+        except Exception as exc:  # noqa: BLE001 - one bad module must not kill lookups
+            # A placeholder whose module now fails to import: drop its
+            # placeholders so we don't retry on every access, and surface
+            # nothing (behaves like an absent link, same as eager's skip).
+            print(
+                f"lazy discovery: skipping `{module_name}` "
+                f"({type(exc).__name__} raised at import: {exc})")
+            for key in [k for k, v in self._index.items() if v == module_name]:
+                del self._index[key]
+            return
+        for key in [k for k, v in self._index.items() if v == module_name]:
+            short = key.rsplit(".", 1)[-1]
+            cls = classes.get(short)
+            if cls is not None:
+                self._resolved[key] = cls
+            del self._index[key]
+
+    def _materialize_key(self, key):
+        module_name = self._index.get(key)
+        if module_name is not None:
+            self._materialize_module(module_name)
+
+    def materialize_all(self):
+        """Import every placeholder module — used before enumerating VALUES."""
+        for module_name in sorted(set(self._index.values())):
+            self._materialize_module(module_name)
+
+    # -- mapping protocol --------------------------------------------------
+
+    def __contains__(self, key):
+        return key in self._resolved or key in self._index
+
+    def __getitem__(self, key):
+        if key in self._resolved:
+            return self._resolved[key]
+        if key in self._index:
+            self._materialize_key(key)
+            if key in self._resolved:
+                return self._resolved[key]
+        raise KeyError(key)
+
+    def get(self, key, default=None):
+        if key in self._resolved:
+            return self._resolved[key]
+        if key in self._index:
+            self._materialize_key(key)
+        return self._resolved.get(key, default)
+
+    def __setitem__(self, key, value):
+        self._index.pop(key, None)
+        self._resolved[key] = value
+
+    def __delitem__(self, key):
+        existed = False
+        if key in self._resolved:
+            del self._resolved[key]
+            existed = True
+        if key in self._index:
+            del self._index[key]
+            existed = True
+        if not existed:
+            raise KeyError(key)
+
+    def __iter__(self):
+        seen = set(self._resolved)
+        yield from self._resolved
+        for key in self._index:
+            if key not in seen:
+                yield key
+
+    def __len__(self):
+        return len(set(self._resolved) | set(self._index))
+
+    def keys(self):
+        return list(self)
+
+    def names(self):
+        """All known link names without importing anything (alias of keys)."""
+        return list(self)
+
+    def items(self):
+        self.materialize_all()
+        return self._resolved.items()
+
+    def values(self):
+        self.materialize_all()
+        return self._resolved.values()
+
+    def pop(self, key, *default):
+        if key in self._resolved:
+            self._index.pop(key, None)
+            return self._resolved.pop(key)
+        if key in self._index:
+            del self._index[key]
+            if key in self._resolved:
+                return self._resolved.pop(key)
+        if default:
+            return default[0]
+        raise KeyError(key)
+
+    def update(self, other):
+        for key, value in dict(other).items():
+            self[key] = value
+
+    def setdefault(self, key, default=None):
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+
+    def copy(self):
+        """Shallow copy that preserves placeholders (does NOT materialize)."""
+        return LazyLinkRegistry(resolved=self._resolved, index=self._index)
+
+    # Convenience / introspection ----------------------------------------
+
+    @property
+    def resolved_count(self):
+        return len(self._resolved)
+
+    @property
+    def pending_count(self):
+        return len(self._index)
+
+    def __repr__(self):
+        return (
+            f"LazyLinkRegistry(resolved={len(self._resolved)}, "
+            f"pending={len(self._index)})")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigraph-schema"
-version = "1.4.5"
+version = "1.5.0"
 description = "A serializable type schema for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_lazy_discovery.py
+++ b/tests/test_lazy_discovery.py
@@ -1,0 +1,223 @@
+"""Tests for lazy process discovery.
+
+Covers the LazyLinkRegistry mapping contract, the "resolve a process without
+importing the whole ecosystem" guarantee, name enumeration without imports,
+eager-mode parity, and the on-disk index cache. See
+``bigraph_schema/package/lazy_registry.py`` and
+``bigraph_schema/package/discover.py``.
+"""
+
+import os
+import sys
+import time
+import textwrap
+
+import pytest
+
+import bigraph_schema.core as core_module
+from bigraph_schema.core import allocate_core
+from bigraph_schema.package.lazy_registry import LazyLinkRegistry
+from bigraph_schema.package import discover as D
+# Contract: these must remain importable for downstream eager consumers.
+from bigraph_schema.package.discover import (  # noqa: F401
+    recursive_dynamic_import,
+    find_edges,
+    find_types,
+    discover_packages,
+)
+
+
+# ---------------------------------------------------------------------------
+# A real, importable throwaway package whose import is observable
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def lazy_pkg(tmp_path, monkeypatch):
+    """Create an importable module with an observable import side effect.
+
+    Returns ``(module_name, marker_path)``. The module writes ``marker_path``
+    when it is imported, so a test can assert import did / did not happen.
+    """
+    marker = tmp_path / "IMPORTED"
+    name = "bgs_lazy_probe_pkg"
+    src = tmp_path / f"{name}.py"
+    src.write_text(textwrap.dedent(f"""
+        import pathlib
+        pathlib.Path(r"{marker}").write_text("x")
+
+        from bigraph_schema import Edge
+
+        class ProbeProcess(Edge):
+            pass
+    """))
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop(name, None)
+    yield name, marker
+    sys.modules.pop(name, None)
+
+
+# ---------------------------------------------------------------------------
+# LazyLinkRegistry unit behaviour
+# ---------------------------------------------------------------------------
+
+class TestLazyLinkRegistry:
+
+    def test_enumeration_does_not_import(self, lazy_pkg):
+        name, marker = lazy_pkg
+        reg = LazyLinkRegistry(
+            resolved={"edge": object},
+            index={"ProbeProcess": name, f"{name}.ProbeProcess": name})
+
+        # Names, membership, len — all without importing.
+        assert "ProbeProcess" in reg
+        assert "edge" in reg
+        assert "ProbeProcess" in reg.keys()
+        assert set(reg.names()) == {"edge", "ProbeProcess", f"{name}.ProbeProcess"}
+        assert len(reg) == 3
+        assert not marker.exists(), "enumeration must not import the module"
+        assert name not in sys.modules
+
+    def test_get_imports_only_on_resolve(self, lazy_pkg):
+        name, marker = lazy_pkg
+        reg = LazyLinkRegistry(index={"ProbeProcess": name})
+        assert not marker.exists()
+
+        cls = reg.get("ProbeProcess")
+        assert cls is not None and cls.__name__ == "ProbeProcess"
+        assert marker.exists(), "get() must import the backing module"
+        # Second lookup is served from the resolved cache.
+        assert reg.get("ProbeProcess") is cls
+
+    def test_get_missing_returns_default(self, lazy_pkg):
+        name, _ = lazy_pkg
+        reg = LazyLinkRegistry(index={"ProbeProcess": name})
+        assert reg.get("does_not_exist") is None
+        assert reg.get("does_not_exist", 42) == 42
+        with pytest.raises(KeyError):
+            reg["does_not_exist"]
+
+    def test_items_materializes(self, lazy_pkg):
+        name, marker = lazy_pkg
+        reg = LazyLinkRegistry(index={"ProbeProcess": name})
+        items = dict(reg.items())
+        assert items["ProbeProcess"].__name__ == "ProbeProcess"
+        assert marker.exists()
+
+    def test_copy_preserves_placeholders(self, lazy_pkg):
+        name, marker = lazy_pkg
+        reg = LazyLinkRegistry(index={"ProbeProcess": name})
+        clone = reg.copy()
+        assert "ProbeProcess" in clone
+        assert not marker.exists(), "copy() must not materialize"
+        # Resolving on the clone doesn't require the original.
+        assert clone.get("ProbeProcess").__name__ == "ProbeProcess"
+
+    def test_setitem_supersedes_placeholder(self, lazy_pkg):
+        name, marker = lazy_pkg
+        reg = LazyLinkRegistry(index={"ProbeProcess": name})
+        sentinel = object()
+        reg["ProbeProcess"] = sentinel
+        assert reg.get("ProbeProcess") is sentinel
+        assert not marker.exists(), "explicit set must not import"
+
+
+# ---------------------------------------------------------------------------
+# allocate_core: lazy default, eager opt-in, parity
+# ---------------------------------------------------------------------------
+
+def _reset_cached_cores():
+    core_module._cached_base_core = None
+    core_module._cached_base_core_eager = None
+
+
+class TestAllocateCore:
+
+    def test_default_is_lazy_registry(self):
+        _reset_cached_cores()
+        core = allocate_core()
+        assert isinstance(core.link_registry, LazyLinkRegistry)
+
+    def test_eager_is_plain_dict(self):
+        _reset_cached_cores()
+        core = allocate_core(eager=True)
+        assert type(core.link_registry) is dict
+
+    def test_eager_lazy_name_parity(self):
+        """Lazy and eager discovery must expose the same link + type names."""
+        _reset_cached_cores()
+        eager = allocate_core(eager=True)
+        _reset_cached_cores()
+        lazy = allocate_core()
+
+        assert set(eager.link_registry.keys()) == set(lazy.link_registry.keys())
+        assert set(eager.registry.keys()) == set(lazy.registry.keys())
+
+    def test_base_edge_link_present(self):
+        _reset_cached_cores()
+        core = allocate_core()
+        assert "edge" in core.link_registry
+
+    def test_list_processes_enumerates_without_import(self, lazy_pkg):
+        """Core.list_processes returns names for a lazy registry."""
+        name, marker = lazy_pkg
+        _reset_cached_cores()
+        core = allocate_core()
+        # Inject a placeholder and confirm it is enumerated but not imported.
+        core.link_registry._index["ProbeProcess"] = name
+        assert "ProbeProcess" in core.list_processes()
+        assert not marker.exists()
+
+    def test_isolated_copy_does_not_materialize(self, lazy_pkg):
+        name, marker = lazy_pkg
+        _reset_cached_cores()
+        allocate_core()  # populates the cached base core
+        # Inject a placeholder into the CACHED base; every subsequent
+        # allocate_core() returns an isolated copy of it.
+        core_module._cached_base_core.link_registry._index["ProbeProcess"] = name
+        clone = allocate_core()
+        assert "ProbeProcess" in clone.link_registry
+        assert not marker.exists(), "copying a cached base must not import"
+
+
+# ---------------------------------------------------------------------------
+# Cold-start improvement (coarse, deterministic)
+# ---------------------------------------------------------------------------
+
+def test_lazy_cold_start_not_slower_than_eager():
+    """Lazy allocate_core() must not be materially slower than eager.
+
+    On any real install with heavy edge-only packages lazy is dramatically
+    faster; on a minimal install (bigraph-schema alone) they are comparable.
+    This asserts the guard direction with generous slack so it is not flaky.
+    """
+    _reset_cached_cores()
+    t = time.perf_counter()
+    allocate_core(eager=True)
+    eager_dt = time.perf_counter() - t
+
+    _reset_cached_cores()
+    allocate_core()  # warm the disk cache
+    _reset_cached_cores()
+    t = time.perf_counter()
+    allocate_core()
+    lazy_dt = time.perf_counter() - t
+
+    assert lazy_dt <= eager_dt + 0.5, (
+        f"lazy cold start {lazy_dt:.3f}s slower than eager {eager_dt:.3f}s")
+
+
+# ---------------------------------------------------------------------------
+# Disk index cache
+# ---------------------------------------------------------------------------
+
+def test_index_cache_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("BIGRAPH_SCHEMA_CACHE_DIR", str(tmp_path))
+    _reset_cached_cores()
+    core = allocate_core()  # writes cache
+    files = list(tmp_path.glob("index-*.json"))
+    assert files, "lazy discovery should have written an index cache file"
+
+    # A second cold allocate should reuse it (still a lazy registry, same names).
+    _reset_cached_cores()
+    core2 = allocate_core()
+    assert set(core.link_registry.keys()) == set(core2.link_registry.keys())


### PR DESCRIPTION
## Problem

`allocate_core()`'s cold cost was dominated by **eager discovery**:
`recursive_dynamic_import` walked every bigraph-schema-dependent distribution
and imported every submodule — including heavy ones (torch, vEcoli, copasi,
spatio-flux) — even when a composite instantiates two processes. In the v2ecoli
15-lib venv that was ~88% of a 6.1s cold start. Every subprocess-isolated run
and every Ray actor pays this per worker, so a 100-run sweep burns ~10 min here.

## Change: discovery is LAZY by default

- **`LazyLinkRegistry`** (new) replaces the plain-dict `link_registry`. It knows
  every process **name** up front, so enumeration / membership / `keys()` do
  **zero imports** — the "list every available process" callers (workbench
  Registry tab, `vivarium-interface` `_add_edge` validation, `/list-processes`)
  keep working. Fetching a **class** via `get()`/`[]` imports just that one
  module on first use. `items()`/`values()`/`dict()` transparently materialize,
  so class-consuming callers (workbench catalog, spatio-flux) stay correct.
- **name→module index**, derived from a one-time real eager pass and **memoized
  to disk**, keyed by installed process-lib versions **+ source mtimes**
  (editable-install safe). Later cold starts read the cache and skip importing
  heavy edge-only packages.
- **Types stay eager** (they cannot be triggered by address resolution) but only
  lightweight type-bearing modules are imported; `register_types` hooks and
  `Node` types are replayed in the **exact eager order** (hooks first, then Node
  types) to preserve registration ordering.
- **Escape hatches:** `allocate_core(eager=True)` / `BIGRAPH_SCHEMA_LAZY_DISCOVERY=0`
  force classic import-everything + plain-dict. `Core.list_processes()`
  enumerates names without importing; `Core.materialize_links()` forces full
  resolution.
- `recursive_dynamic_import` / `find_edges` / `find_types` keep their signatures,
  so the eager discovery contract downstreams rely on is unchanged.

## Measured (representative subset: process-bigraph + 3 light + torch + sklearn dists)

Isolated `allocate_core()` call, warm-disk fresh process (the recurring
per-worker cost):

| mode | allocate_core() | torch/sklearn imported |
|------|-----------------|------------------------|
| eager | 1.10s | yes |
| lazy (cache hit) | **0.16s** | **no** |

**~6.9x** with only two heavy dists; the eager cost scales with heavy-dist count
while lazy stays flat, so the full v2ecoli 15-lib set lands in the ~8–10x range.
A 2-process composite runs correctly and imports **neither** torch nor sklearn.

## Tests

- Full bigraph-schema suite green (25 passed: 11 existing + 14 new).
- process-bigraph suite green against this branch (28 passed) + a 2-process
  composite run producing correct outputs with no heavy imports.
- New `tests/test_lazy_discovery.py`: LazyLinkRegistry contract (enumerate
  without import, import-on-resolve, `items()` materializes, `copy()` preserves
  placeholders), eager/lazy **name + type parity**, isolated-copy never
  materializes, cold-start guard, disk-cache roundtrip.

## Blast radius verified

Swept `~/code/*` for `link_registry` consumers. Confirmed still working under
lazy: name enumeration/membership (interface validation, `/list-processes`),
`.items()`/`dict()` class-consumers (workbench catalog, spatio-flux),
`_isolated_copy` (no materialization), eager mode, and editable-install cache
invalidation.

Do not merge / no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)